### PR TITLE
Removed indentation for multiqc sthlm config

### DIFF
--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -13,7 +13,7 @@ megaqc_access_token: {{ megaqc_access_token }}
 {% endfor %}
 
 {% if site == "sthlm" %}
-  remote_sshkey: {{ multiqc_sshkey }}
-  remote_port: {{ multiqc_port }}
-  remote_destination: {{ multiqc_destination }}
+remote_sshkey: {{ multiqc_sshkey }}
+remote_port: {{ multiqc_port }}
+remote_destination: {{ multiqc_destination }}
 {% endif %}


### PR DESCRIPTION
I think the indentation wasn't intentional but the yaml parsing fails due to it (I tried removing it and I think that fixed it)