### PR TITLE
Set key in header to true for tarzan

### DIFF
--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -32,7 +32,7 @@ plugins:
       key_names:
       - apikey
       key_in_body: false
-      key_in_header: false
+      key_in_header: true
       key_in_query: true
       hide_credentials: true
 


### PR DESCRIPTION
This is a bug fix that showed up in miarka validation. Tarzan must accept api authentication key in the header, since snpseq-packs uses request header when authenticating.