### PR TITLE
Update dds-cli to 0.0.11

### DIFF
--- a/roles/dds_cli/defaults/main.yml
+++ b/roles/dds_cli/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-dds_cli_version: 0.0.10
+dds_cli_version: 0.0.11


### PR DESCRIPTION
This updates dds-cli to 0.0.11. 

Changes:

- Timeout for requests changed from 5 to 30 seconds
- Improved message after some files have been previously uploaded (not “error”)
- A confirmation prompt when attempting to delete the projects
