### PR TITLE
Add dependency for anaconda

### DIFF
--- a/roles/anaconda/tasks/main.yml
+++ b/roles/anaconda/tasks/main.yml
@@ -3,7 +3,7 @@
     url: "{{ anaconda_url }}"
     dest: "{{ anaconda_src }}"
     checksum: sha256:{{ anaconda_checksum }}
-    mode: "0755"
+    mode: 0755
 
 - name: Install anaconda
   shell: "{{ anaconda_src }} -b -p {{ anaconda_path }}"

--- a/roles/anaconda/tasks/main.yml
+++ b/roles/anaconda/tasks/main.yml
@@ -3,6 +3,7 @@
     url: "{{ anaconda_url }}"
     dest: "{{ anaconda_src }}"
     checksum: sha256:{{ anaconda_checksum }}
+    mode: "0755"
 
 - name: Install anaconda
   shell: "{{ anaconda_src }} -b -p {{ anaconda_path }}"

--- a/roles/seqreports/meta/main.yml
+++ b/roles/seqreports/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - { role: nextflow, tags: nextflow }
+  - { role: anaconda, tags: anaconda }


### PR DESCRIPTION
This dependency seem to have been lost during some rebase?

I had to add the mode line in order to run seqreports agains a vmbox. I'm not sure why it works on Miarka though. 