### PR TITLE
Add Nextflow Tower config

### DIFF
--- a/env_secrets/site_all_env_all.yml.example
+++ b/env_secrets/site_all_env_all.yml.example
@@ -13,6 +13,9 @@ snic_api_password: secret
 # ngi_pipeline
 charon_api_token: secret
 
+# Nextflow Tower (should be site-specific)
+tower_workspace_id: secret
+
 # multiqc
 megaqc_access_token: secret
 

--- a/roles/nextflow/templates/nextflow_miarka_site.config.j2
+++ b/roles/nextflow/templates/nextflow_miarka_site.config.j2
@@ -10,6 +10,12 @@ params {
 
 }
 
+tower {
+    workspaceId = '{{ tower_workspace_id }}'
+    endpoint = 'https://ngi-tower.scilifelab.se/api'
+    enabled = true
+}
+
 {% if site == "sthlm" %}
 process {
     withName: 'multiqc|MultiQC|MULTIQC' {


### PR DESCRIPTION
Added the config required to _monitor_ Nextflow runs at https://ngi-tower.scilifelab.se/ (launched the traditional way on the CLI, not launch via Tower)

Requires some additional config:

- Site-specific workspace IDs set in the relevant configs as `tower_workspace_id`
    - These are the `Id` shown for each node at https://ngi-tower.scilifelab.se/orgs/NGI/workspaces
    - When set, will collect all runs in the node's workspace, eg. https://ngi-tower.scilifelab.se/orgs/NGI/workspaces/NGI-Stockholm/watch
- Person-specific Tower access tokens _(outside of miarka-provision)_
    - Each person needs to log in to NGI-Tower and go to https://ngi-tower.scilifelab.se/tokens to create a new token
    - In `.bashrc` or similar, add `export TOWER_ACCESS_TOKEN=<YOUR ACCESS TOKEN>`

Once this is done ☝🏻 no further config is required. Existing launch commands can remain unchanged.

✅  Just tested on Miarka with my custom version of Nextflow (version `21.12.1-edge build 5654`) and it worked first time.
✅  Also tried with `/vulpes/ngi/staging/220401.e758cb1/sw/nextflow/nextflow` (version `21.04.3 build 5563`) and it also worked first time.

That was for a _very_ basic pipeline, but hopefully holds true for all Nextflow pipelines 🤞🏻 