### PR TITLE
fix umask, silence crontab output

### DIFF
--- a/roles/func_accounts/templates/supervisord_site.conf.j2
+++ b/roles/func_accounts/templates/supervisord_site.conf.j2
@@ -1,3 +1,4 @@
 [supervisord]
 logfile={{ supervisord_log_dest }}/supervisord.log
 pidfile={{ supervisord_log_dest }}/supervisord.pid
+umask=007

--- a/roles/tarzan/tasks/install_tarzan.yml
+++ b/roles/tarzan/tasks/install_tarzan.yml
@@ -50,7 +50,7 @@
 
 - name: modify uppsala's crontab to start kong
   lineinfile: dest="{{ ngi_pipeline_conf }}/crontab_upps"
-              line='38 * * * *      source $HOME/.bash_profile && {{ tarzan_start_script }}'
+              line='38 * * * *      source $HOME/.bash_profile && {{ tarzan_start_script }} &> /dev/null'
               backup=no
 
 - name: Store tarzan tools version in deployment


### PR DESCRIPTION
This ensures that the `supervisord` process uses the correct `umask` when launching processes. Also silences output from the Tarzan start script in the crontab.
