### PR TITLE
Update hsmetrics location

### DIFF
--- a/roles/nf-core/templates/DELIVERY.README.SAREK.WES.md.j2
+++ b/roles/nf-core/templates/DELIVERY.README.SAREK.WES.md.j2
@@ -49,13 +49,11 @@ After running the pipeline, Picard CollectHsMetrics was used to evaluate the cov
 │           ├── <sample2 name>.md.bam.bai
 │           └── <sample2 name>.recal.table
 ├── Reports
-│   ├── HsMetrics
-│   │   ├── <sample1 name>
-│   │   └── <sample2 name>
 │   ├── <sample1 name>
 │   │   ├── bamQC
 │   │   ├── BCFToolsStats
 │   │   ├── FastQC
+│   │   ├── HsMetrics
 │   │   ├── MarkDuplicates
 │   │   ├── SamToolsStats
 │   │   ├── snpEff
@@ -64,6 +62,7 @@ After running the pipeline, Picard CollectHsMetrics was used to evaluate the cov
 │       ├── bamQC
 │       ├── BCFToolsStats
 │       ├── FastQC
+│       ├── HsMetrics
 │       ├── MarkDuplicates
 │       ├── SamToolsStats
 │       ├── snpEff

--- a/roles/nf-core/templates/DELIVERY.README.SAREK.txt.j2
+++ b/roles/nf-core/templates/DELIVERY.README.SAREK.txt.j2
@@ -4,6 +4,17 @@ README
 The README describes the content of the delivered data.
 -----------------------------------------------------------------
 
+Samples were analysed with the Sarek pipeline release {{ release }}. In short, the pipeline does the following:
+Reads from fastq-files were mapped to a reference genome using BWA.
+Bam-files were de-duplicated with GATK MarkDuplicates.
+Base quality score recalibration tables were created with GATK BaseRecalibrator. 
+The tables were then used in GATK ApplyBQSR to create recalibrated bam-files.
+SNVs and small indels were called with GATK HaplotypeCaller.
+Variants were annoted with SnpEff.
+
+For details on the pipeline, folder structure and how to interpret results, please refer to the Sarek documentation:
+https://nf-co.re/sarek/{{ release }}
+
 Root level
 ----------
 The root folder, which is named by the project id, contains one report folder,

--- a/roles/taca/templates/site_taca_sarek_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_delivery.yml.j2
@@ -12,54 +12,68 @@ deliver:
         -
             - <ANALYSISPATH>/seqreports/*
             - <STAGINGPATH>/00-Reports/SequenceQC/
-            - required: True
+            - 
+              required: True
         -
             - <ANALYSISPATH>/multiqc_ngi/*multiqc_report.html
             - <STAGINGPATH>/00-Reports/
-            - required: True
+            - 
+              required: True
         -
             - <ANALYSISPATH>/multiqc_ngi/*multiqc_report_data.zip
             - <STAGINGPATH>/00-Reports/
-            - required: True
+            - 
+              required: True
         -
             - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Annotation/<SAMPLEID>/*
             - <STAGINGPATH>/<SAMPLEID>/results/Annotation/
-            - required: True
+            - 
+              required: True
         -
             - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/pipeline_info/results_description.html
             - <STAGINGPATH>/<SAMPLEID>/results/pipeline_info
-            - required: True
+            - 
+              required: True
         -
             - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/pipeline_info/software_versions.csv
             - <STAGINGPATH>/<SAMPLEID>/results/pipeline_info
-            - required: True
+            - 
+              required: True
         -
             - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Preprocessing/TSV/duplicates_marked*<SAMPLEID>.tsv*
             - <STAGINGPATH>/<SAMPLEID>/results/Preprocessing/TSV
-            - required: True
+            - 
+              required: True
         -
             - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Preprocessing/<SAMPLEID>/DuplicatesMarked/*
             - <STAGINGPATH>/<SAMPLEID>/results/Preprocessing/DuplicatesMarked
-            - required: True
+            - 
+              required: True
         -
             - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Reports/*
             - <STAGINGPATH>/<SAMPLEID>/results/Reports
-            - required: True
+            - 
+              required: True
         -
             - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/VariantCalling/<SAMPLEID>/*
             - <STAGINGPATH>/<SAMPLEID>/results/VariantCalling/
-            - required: True
+            - 
+              required: True
         -
             - {{ ngi_softlinks }}/ACKNOWLEDGEMENTS.txt
             - <STAGINGPATH>
         -
             - {{ ngi_resources }}/TACA/{{ site }}/DELIVERY.README.SAREK.txt
             - <STAGINGPATH>
-            - required: True
+            - 
+              required: True
+              no_digest_cache: True
         -
             - {{ ngi_resources }}/TACA/apply_recalibration.sh
             - <STAGINGPATH>/01-Resources/
-            - required: True
+            -
+              required: True
+              no_digest_cache: True
 {% endif %}
 {% if "sthlm" == site %}
     datapath: <ROOTPATH>/DATA/<PROJECTID>

--- a/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
@@ -40,34 +40,29 @@ deliver:
           -
             required: True
         -
-            - <ANALYSISPATH>/results/Preprocessing/<SAMPLEID>/DuplicatesMarked/*
-            - <STAGINGPATH>/Preprocessing/<SAMPLEID>/DuplicatesMarked/
-            -
-              required: True
+          - <ANALYSISPATH>/results/Preprocessing/<SAMPLEID>/DuplicatesMarked/*
+          - <STAGINGPATH>/Preprocessing/<SAMPLEID>/DuplicatesMarked/
+          -
+            required: True
         -
-            - <ANALYSISPATH>/results/Reports/<SAMPLEID>/
-            - <STAGINGPATH>/Reports/<SAMPLEID>/
-            -
-              required: True
+          - <ANALYSISPATH>/results/Reports/<SAMPLEID>/
+          - <STAGINGPATH>/Reports/<SAMPLEID>/
+          -
+            required: True
         -
-            - <ANALYSISPATH>/results/Reports/HsMetrics/<SAMPLEID>*
-            - <STAGINGPATH>/Reports/HsMetrics/<SAMPLEID>/
-            -
-              required: True
+          - <ANALYSISPATH>/results/VariantCalling/<SAMPLEID>/
+          - <STAGINGPATH>/VariantCalling/<SAMPLEID>/
+          -
+            required: True
         -
-            - <ANALYSISPATH>/results/VariantCalling/<SAMPLEID>/
-            - <STAGINGPATH>/VariantCalling/<SAMPLEID>/
-            -
-              required: True
+          - {{ ngi_resources }}/TACA/{{ site }}/DELIVERY.README.SAREK.WES.md
+          - <STAGINGPATH>/
+          -
+            required: True
+            no_digest_cache: True
         -
-            - {{ ngi_resources }}/TACA/{{ site }}/DELIVERY.README.SAREK.WES.md
-            - <STAGINGPATH>/
-            -
-              required: True
-              no_digest_cache: True
-        -
-            - {{ ngi_resources }}/TACA/apply_recalibration.sh
-            - <STAGINGPATH>/Resources/
-            -
-              required: True
-              no_digest_cache: True
+          - {{ ngi_resources }}/TACA/apply_recalibration.sh
+          - <STAGINGPATH>/Resources/
+          -
+            required: True
+            no_digest_cache: True


### PR DESCRIPTION
These changes should only affect Uppsala's files: 

- Updated delivery readmes and taca configs to reflect location of hs-metrics report
- Some indentation fixes to taca configs
- Some addition to delivery readmes