### PR TITLE
Update arteria-delivery to 2.6.0-rc1

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v2.5.0
+arteria_delivery_version: v2.6.0-rc1
 
 arteria_service_name: arteria-delivery-ws
 

--- a/roles/arteria-delivery-ws/templates/delivery_app.config.j2
+++ b/roles/arteria-delivery-ws/templates/delivery_app.config.j2
@@ -12,3 +12,4 @@ path_to_mover: "{{ mover_path }}"
 project_links_directory: "{{ delivery_links }}"
 dds_conf:
   log_path: "{{ arteria_service_log_dir }}/dds.log"
+  mount_dir: "{{ lookup('env', 'SNIC_TMP') }}"$


### PR DESCRIPTION
During testing, we realized DDS needs to create its own staging directory. By default, this goes into the current working directory. However, we suspect `funk004` does not have sufficient permission to do that in the case of the delivery workflows.

This PR sets the DDS staging directory to the scratch partition.