### PR TITLE
Link delivery readmes

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -41,3 +41,7 @@ pipelines:
     release: 2.0.0
   - name: nanoseq
     release: 1.1.0
+
+nf_core_delivery_readmes:
+  - DELIVERY.README.SAREK.txt
+  - DELIVERY.README.SAREK.WES.md

--- a/roles/nf-core/tasks/main.yml
+++ b/roles/nf-core/tasks/main.yml
@@ -20,6 +20,19 @@
     container_dir: "{{ ngi_containers }}/{{ item.container_dir | default(item.name) }}"
   with_items: "{{ pipelines }}"
 
+- name: Deploy script for softlinking delivery Readmes
+  template:
+    src: create_delivery_readme_softlinks.sh.j2
+    dest: "{{ ngi_resources }}/create_nfcore_delivery_readme_softlinks_{{ site }}.sh"
+
+- name: add static folders to be created
+  set_fact:
+    static_folders: "{{ static_folders + [ngi_softlinks] }}"
+
+- name: add static commands to be run
+  set_fact:
+    static_commands: "{{ static_commands + ['. ' ~ ngi_resources ~ '/create_nfcore_delivery_readme_softlinks_' ~ site ~ '.sh'] }}"
+
 - name: Store nf-core version in deployment
   lineinfile:
     dest: "{{ deployed_tool_versions }}"

--- a/roles/nf-core/templates/create_delivery_readme_softlinks.sh.j2
+++ b/roles/nf-core/templates/create_delivery_readme_softlinks.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Minimalistic script that links {{ site }}-specific
-# delivery readmes for taca and nextflow pipelines
+# delivery readmes and scripts for taca and nextflow pipelines
 
 {% for readme in nf_core_delivery_readmes | default([]) | sort %}
 if [ -e "{{ ngi_resources }}/TACA/{{ site }}/{{ readme }}" ]
@@ -13,3 +13,12 @@ then
   ln -s {{ ngi_resources }}/TACA/{{ site }}/{{ readme }} {{ ngi_softlinks }}/{{ readme }}
 fi
 {% endfor %}
+
+if [ -e "{{ ngi_resources }}/TACA/apply_recalibration.sh" ]
+then
+  # remove existing link (including checksum)
+  rm -f {{ ngi_softlinks }}/apply_recalibration.sh
+  rm -f {{ ngi_softlinks }}/apply_recalibration.sh.md5
+  # create symlink
+  ln -s {{ ngi_resources }}/TACA/apply_recalibration.sh {{ ngi_softlinks }}/apply_recalibration.sh
+fi

--- a/roles/nf-core/templates/create_delivery_readme_softlinks.sh.j2
+++ b/roles/nf-core/templates/create_delivery_readme_softlinks.sh.j2
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Minimalistic script that links {{ site }}-specific
+# delivery readmes for taca and nextflow pipelines
+
+{% for readme in nf_core_delivery_readmes | default([]) | sort %}
+if [ -e "{{ ngi_resources }}/TACA/{{ site }}/{{ readme }}" ]
+then
+  # remove existing link (including checksum)
+  rm -f {{ ngi_softlinks }}/{{ readme }}
+  rm -f {{ ngi_softlinks }}/{{ readme }}.md5
+  # create symlink
+  ln -s {{ ngi_resources }}/TACA/{{ site }}/{{ readme }} {{ ngi_softlinks }}/{{ readme }}
+fi
+{% endfor %}

--- a/roles/taca/templates/site_taca_sarek_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_delivery.yml.j2
@@ -63,13 +63,13 @@ deliver:
             - {{ ngi_softlinks }}/ACKNOWLEDGEMENTS.txt
             - <STAGINGPATH>
         -
-            - {{ ngi_resources }}/TACA/{{ site }}/DELIVERY.README.SAREK.txt
+            - {{ ngi_softlinks }}/DELIVERY.README.SAREK.txt
             - <STAGINGPATH>
             - 
               required: True
               no_digest_cache: True
         -
-            - {{ ngi_resources }}/TACA/apply_recalibration.sh
+            - {{ ngi_softlinks }}/apply_recalibration.sh
             - <STAGINGPATH>/01-Resources/
             -
               required: True

--- a/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
@@ -55,13 +55,13 @@ deliver:
           -
             required: True
         -
-          - {{ ngi_resources }}/TACA/{{ site }}/DELIVERY.README.SAREK.WES.md
+          - {{ ngi_softlinks }}/DELIVERY.README.SAREK.WES.md
           - <STAGINGPATH>/
           -
             required: True
             no_digest_cache: True
         -
-          - {{ ngi_resources }}/TACA/apply_recalibration.sh
+          - {{ ngi_softlinks }}/apply_recalibration.sh
           - <STAGINGPATH>/Resources/
           -
             required: True


### PR DESCRIPTION
- For NGI-U, some delivery readmes are not linked to the `softlinks` folder and are not properly staged by TACA. This is intended to fix that.
