### PR TITLE
display instruction post-sync

### DIFF
--- a/sync.yml
+++ b/sync.yml
@@ -97,3 +97,6 @@
       when:
         - not deployment_environment == 'devel'
         - not hostvars['deploy']['branch_name'] == 'bimonthly'
+
+    - debug:
+        msg: Done! Each site should now execute {{ hostvars['deploy']['ngi_resources'] }}/create_static_contents_[upps | sthlm].sh


### PR DESCRIPTION
For convenience, print the path to the post-sync script each site should run.