### PR TITLE
Update arteria-delivery to v2.6.0

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v2.5.0
+arteria_delivery_version: v2.6.0-rc1
 
 arteria_service_name: arteria-delivery-ws
 

--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v2.6.0-rc1
+arteria_delivery_version: v2.6.0-rc2
 
 arteria_service_name: arteria-delivery-ws
 

--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v2.6.0-rc2
+arteria_delivery_version: v2.6.0
 
 arteria_service_name: arteria-delivery-ws
 

--- a/roles/arteria-delivery-ws/templates/delivery_app.config.j2
+++ b/roles/arteria-delivery-ws/templates/delivery_app.config.j2
@@ -12,3 +12,4 @@ path_to_mover: "{{ mover_path }}"
 project_links_directory: "{{ delivery_links }}"
 dds_conf:
   log_path: "{{ arteria_service_log_dir }}/dds.log"
+  mount_dir: "{{ lookup('env', 'SNIC_TMP') }}"$

--- a/roles/arteria-delivery-ws/templates/delivery_app.config.j2
+++ b/roles/arteria-delivery-ws/templates/delivery_app.config.j2
@@ -12,4 +12,3 @@ path_to_mover: "{{ mover_path }}"
 project_links_directory: "{{ delivery_links }}"
 dds_conf:
   log_path: "{{ arteria_service_log_dir }}/dds.log"
-  mount_dir: "{{ lookup('env', 'SNIC_TMP') }}"$


### PR DESCRIPTION
We have completed the validation of the new version of arteria-delivery, introducing support for the new delivery system (DDS).

I've talked a bit with @slohse and @matrulda already and we were not sure if this could be deployed already this month or if we should wait for the next cycle, so the idea was to continue the discussion here.

Some considerations that were raised during our discussion:
- This is a rather small backward-compatible change (grus remains the default target)
- We have verified that it is still possible to deliver with mover and with dds in staging
- If we deploy during this cycle we can use arteria-delivery for the pilot project next month and potentially have more margin to fix bugs before grus is decommissioned.