### PR TITLE
install nextflow in nf-core conda environment

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -9,7 +9,7 @@ nf_core_vars:
   NXF_SINGULARITY_CACHEDIR: "{{ container_dir }}"
   NXF_SINGULARITY_LIBRARYDIR: "{{ container_dir }}"
   JAVA_HOME: "{{ nextflow_local_env.NXF_JAVA_HOME }}"
-  PATH: "{{ nf_core_env }}/bin:{{ tools_path.PATH }}:{{ nextflow_dest }}"
+  PATH: "{{ nf_core_env }}/bin:{{ tools_path.PATH }}"
 biocontainers_dirname: biocontainers
 pipelines:
   - name: rnaseq

--- a/roles/nf-core/tasks/main.yml
+++ b/roles/nf-core/tasks/main.yml
@@ -4,7 +4,7 @@
   register: "nfcore_envs"
 
 - name: Setup {{ nf_core_env_name }} virtual env with python3 and nf-core v{{ nf_core_version }}
-  command: "conda create -n {{ nf_core_env_name }} -c conda-forge -c bioconda -c anaconda python={{ python3_version }} nf-core={{ nf_core_version }}"
+  command: "conda create -n {{ nf_core_env_name }} -c conda-forge -c bioconda -c anaconda python={{ python3_version }} nf-core={{ nf_core_version }} nextflow={{ nextflow_version_tag }}"
   when: not nf_core_env_name in nfcore_envs.stdout|split
 
 # Setup pipelines


### PR DESCRIPTION
Having `nf-core` use the already deployed `nextflow` binary didn't work properly, probably because the environment was not correctly passed into the task. This PR instead haves `nf-core` deploy its own `Nextflow` into the Conda environment.