### PR TITLE
Restore arteria-delivery config change concerning dds

### DIFF
--- a/roles/arteria-delivery-ws/templates/delivery_app.config.j2
+++ b/roles/arteria-delivery-ws/templates/delivery_app.config.j2
@@ -10,3 +10,5 @@ port: "{{ arteria_delivery_port }}"
 alembic_path: "{{ alembic_path }}"
 path_to_mover: "{{ mover_path }}"
 project_links_directory: "{{ delivery_links }}"
+dds_conf:
+  log_path: "{{ arteria_service_log_dir }}/dds.log"


### PR DESCRIPTION
This PR adds a change that was verified in the bimonthly month, but missed out when merging changes to the monthly branch. I think think was due to an unfortunate combination of first reverting the arteria-delivery changes from the monthly branch and then forgetting to add it again. Also the fact that the changes was merged before merging the whole bimonthly branch into monthly. 

This change has been hot-fixed in `vulpes/ngi/production/v22.06-3/conf/arteria/arteria-delivery-ws/app.config`