### PR TITLE
update nf-core to 2.4.1, properly set NXF_HOME for nf-core

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -1,6 +1,6 @@
 nf_core_env_name: nf-core-env
 nf_core_env: "{{ sw_path }}/anaconda/envs/{{ nf_core_env_name }}"
-nf_core_version: 2.1
+nf_core_version: 2.4.1
 nf_core_container_repo: docker://nfcore
 nf_core_vars:
   NFCORE_NO_VERSION_CHECK: 1
@@ -8,6 +8,7 @@ nf_core_vars:
   SINGULARITY_TMPDIR: /scratch/{{ deployment_version }}/singularity_temp
   NXF_SINGULARITY_CACHEDIR: "{{ container_dir }}"
   NXF_SINGULARITY_LIBRARYDIR: "{{ container_dir }}"
+  NXF_HOME: "{{ nextflow_local_env.NXF_HOME }}"
   JAVA_HOME: "{{ nextflow_local_env.NXF_JAVA_HOME }}"
   PATH: "{{ nf_core_env }}/bin:{{ tools_path.PATH }}"
 biocontainers_dirname: biocontainers


### PR DESCRIPTION
The `nf-core download` command didn't see the correct `NXF_HOME` environment variable when run by Ansible which caused the download of additional pipeline containers to fail. This should fix that.

Also bumps nf-core to 2.4.1
