### PR TITLE
Update arteria delivery (v2.6.2) and dds-cli (v1.1.0)

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v2.6.0
+arteria_delivery_version: v2.6.2
 
 
 arteria_service_name: arteria-delivery-ws

--- a/roles/dds_cli/defaults/main.yml
+++ b/roles/dds_cli/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-dds_cli_version: 1.0.73
+dds_cli_version: 1.1.0


### PR DESCRIPTION
This PR updates:

- arteria-delivery to v2.6.2, which will be validated in the staging environment. 

- dds-cli to the [latest version](https://github.com/ScilifelabDataCentre/dds_cli/releases/tag/v1.1.0). It should not contain any breaking changes, the minor changes are related to the `dds auth twofactor` command.
