### PR TITLE
Update nanoseq to v3.0.0 and fix bug in ngi_reports dependency

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -38,9 +38,10 @@ pipelines:
     release: 2.2
     container_dir: "{{ biocontainers_dirname }}"
   - name: rnafusion
-    release: 2.0.0
+    release: 2.1.0
   - name: nanoseq
-    release: 1.1.0
+    release: 3.0.0
+    container_dir: "{{ biocontainers_dirname }}"
 
 nf_core_delivery_readmes:
   - DELIVERY.README.SAREK.txt

--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -10,4 +10,4 @@ ngi_visual_version: bf1892faf5ebe16ad0979cfc83f9c72b90e2a5a0
 
 ngi_mdx_outline_repo: https://github.com/NationalGenomicsInfrastructure/mdx_outline.git
 ngi_mdx_outline_dest: "{{ sw_path }}//mdx_outline"
-ngi_mdx_outline_version: 07fae9d91c348818a1627b5ecb560f52e9153d33
+ngi_mdx_outline_version: f850211dca38b75873b7e60a23af24201426b58d


### PR DESCRIPTION
To be included in this month's deployment