### PR TITLE
Run arteria-delivery in py3.8 env

### DIFF
--- a/roles/arteria-delivery-ws/tasks/install.yml
+++ b/roles/arteria-delivery-ws/tasks/install.yml
@@ -1,6 +1,6 @@
 
 - name: create virtual python env for arteria-delivery
-  shell: "conda create --name {{ arteria_service_name }} python=3.6"
+  shell: "conda create --name {{ arteria_service_name }} python=3.8"
   args: 
     creates: "{{ arteria_service_env_root }}"
 


### PR DESCRIPTION
This PR solves an issue with dds-cli, which does not support 3.6 (which makes sense since it has reached EOL). 

Unit tests passing for arteria-delivery, as well as devel deployment of this role on Miarka3. 