### PR TITLE
use common container folder for dependencies

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -40,11 +40,13 @@ pipelines:
     container_dir: "{{ biocontainers_dirname }}"
   - name: rnafusion
     release: 2.1.0
+    container_dir: "{{ biocontainers_dirname }}"
   - name: nanoseq
     release: 3.0.0
     container_dir: "{{ biocontainers_dirname }}"
   - name: scrnaseq
     release: 2.0.0
+    container_dir: "{{ biocontainers_dirname }}"
 
 nf_core_delivery_readmes:
   sarek:


### PR DESCRIPTION
- In order to re-use containers, point pipelines that use dependencies to a common location