### PR TITLE
Update arteria-delivery to v2.6.3-rc1

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v2.6.2
+arteria_delivery_version: v2.6.3-rc1
 
 
 arteria_service_name: arteria-delivery-ws


### PR DESCRIPTION
This should address the latest bugs uncovered during the validation of `arteria-delivery`.