### PR TITLE
Taca batch wgs delivery

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -51,10 +51,10 @@ pipelines:
 nf_core_delivery_readmes:
   sarek:
     - DELIVERY.README.SAREK.txt
+    - DELIVERY.README.SAREK.BATCH.txt
     - DELIVERY.README.SAREK.WES.md
     - apply_recalibration.sh
   rnaseq:
     - DELIVERY.README.RNASEQ.md
   methylseq:
     - DELIVERY.README.METHYLSEQ.md
-

--- a/roles/nf-core/templates/DELIVERY.README.SAREK.BATCH.txt.j2
+++ b/roles/nf-core/templates/DELIVERY.README.SAREK.BATCH.txt.j2
@@ -1,0 +1,150 @@
+README
+=======
+
+The README describes the content of the delivered data.
+-----------------------------------------------------------------
+
+Samples were analysed with the Sarek pipeline release {{ release }}. In short, the pipeline does the following:
+Reads from fastq-files were mapped to a reference genome using BWA.
+Bam-files were de-duplicated with GATK MarkDuplicates.
+Base quality score recalibration tables were created with GATK BaseRecalibrator. 
+The tables were then used in GATK ApplyBQSR to create recalibrated bam-files.
+SNVs and small indels were called with GATK HaplotypeCaller.
+Variants were annoted with SnpEff.
+
+For details on the pipeline, folder structure and how to interpret results, please refer to the Sarek documentation:
+https://nf-co.re/sarek/{{ release }}
+
+Root level
+----------
+The root folder, which is named by the project id, contains one report folder,
+one resource folder and one folder for each sample. Each sample folder is
+accompanied by a .lst-file containing a list of the files in the folder and
+a .md5-file containing the MD5-checksums of the files in the folder.
+Use the MD5-checksums to verify the integrity of the files after transfer.
+
+|--ProjectID
+   |--00-Reports
+   |--01-Resources
+   |--Sample1
+   |--Sample1.lst
+   |--Sample1.md5
+   |--Sample2
+   |--Sample2.lst
+   |--Sample2.md5
+   ...
+   ...
+   |--SampleN
+   |--SampleN.lst
+   |--SampleN.md5
+
+====================================================================
+ProjectID -> 00-Reports
+====================================================================
+00-Reports contain sequence QC for flowcells and a project report.
+
+|--ProjectID
+   |--00-Reports
+      |--ProjectID_multiqc_report.html
+{% if site == "upps" %}
+      |--ProjectID_multiqc_report_data.zip
+      |--SequenceQC
+{% endif %}
+
+--ProjectID_multiqc_report.html
+A project report summarizing the included samples and results from the sequencing and analysis.
+
+{% if site == "upps" %}
+--ProjectID_multiqc_report_data.zip
+Source data for the project report.
+
+--SequenceQC
+The SequenceQC folder contain sequence QC data, which provide information about the
+quality and other features of the fastq-files. The reports are organized by sequence run.
+
+{% endif %}
+====================================================================
+ProjectID -> 01-Resources
+====================================================================
+01-Resources contain helper scripts and other resources
+
+|--ProjectID
+   |--01-Resources
+      |--apply_recalibration.sh
+
+--apply_recalibration.sh
+Variant calling has been performed after recalibrating the base quality
+scores of this BAM file (BQSR). However, due to the drastic increase in file
+size during base quality recalibration, the BAM file without recalibrated
+base quality scores is delivered. If recalibrated base qualities are required
+for downstream applications, this script can be used to obtain a recalibrated BAM file.
+
+Note: The BAM file and recalibration table can be found among the sarek results,
+read more below.
+
+====================================================================
+ProjectID -> SampleN
+====================================================================
+Each sample will contain a results folder:
+
+{% if "sthlm" == site %}
+|--ProjectID
+   |--SampleN
+      |--results
+         |--PipelineTool1
+         |--PipelineTool2
+         ...
+         ...
+         |--PipelineToolN
+{% endif %}
+{% if "upps" == site %}
+SampleN
+└── results
+    ├── Annotation
+    │   └── snpEff
+    ├── pipeline_info
+    │   ├── results_description.html
+    │   └── software_versions.csv
+    ├── Preprocessing
+    │   ├── DuplicatesMarked
+    │   │   ├── SampleN.md.bam
+    │   │   ├── SampleN.md.bam.bai
+    │   │   └── SampleN.recal.table
+    │   └── TSV
+    │       ├── duplicates_marked_SampleN.tsv
+    │       └── duplicates_marked_no_table_SampleN.tsv
+    ├── Reports
+    │   └── SampleN
+    │       ├── bamQC
+    │       ├── BCFToolsStats
+    │       ├── FastQC
+    │       ├── MarkDuplicates
+    │       ├── SamToolsStats
+    │       ├── snpEff
+    │       └── VCFTools
+    └── VariantCalling
+        ├── HaplotypeCaller
+        │   ├── HaplotypeCaller_SampleN.vcf.gz
+        │   └── HaplotypeCaller_SampleN.vcf.gz.tbi
+        └── HaplotypeCallerGVCF
+            ├── HaplotypeCaller_SampleN.g.vcf.gz
+            └── HaplotypeCaller_SampleN.g.vcf.gz.tbi
+{% endif %}
+
+Top level folders:
+
+Annotation:     Variant calls annotated with e.g. transcript information and predicted variant effects
+pipeline_info:  Information about pipeline and software versions
+Preprocessing:  BAM files with duplicates marked and tables for performing recalibration with GATK
+Reports:        Statistics and QC from various tools. 
+VariantCalling: VCF and GVCF files containing e.g. SNVs, CNVs, small indels and structural variants.   
+
+This folder contains output from the sarek pipeline. Refer to
+https://nf-co.re/sarek/{{ release }}/docs/output for more detailed output description.
+
+====================================================================
+FASTQS
+====================================================================
+FASTQ files are not included in the delivery, but can be regenerated from the BAM files.
+We recommend using https://github.com/qbic-pipelines/bamtofastq, refer to its documentation
+for usage.

--- a/roles/taca/tasks/main.yml
+++ b/roles/taca/tasks/main.yml
@@ -39,6 +39,7 @@
     - { config_tpl: "taca_delivery", config_dst: "taca_delivery", config_site: ["upps"] }
     - { config_tpl: "taca_delivery", config_dst: "taca_wgs_delivery", config_site: ["sthlm"] }
     - { config_tpl: "taca_sarek_delivery", config_dst: "taca_sarek_delivery" }
+    - { config_tpl: "taca_sarek_delivery", config_dst: "taca_sarek_batch_delivery" }
     - { config_tpl: "taca_sarek_wes_delivery", config_dst: "taca_sarek_wes_delivery", config_site: ["upps"] }
     - { config_tpl: "taca_cleanup", config_dst: "taca_cleanup", item_type: cleanup, config_site: ["sthlm"] }
     - { config_tpl: "app_specific_delivery", config_dst: "taca_fastq_delivery", item_type: fastq, config_site: ["sthlm"] }

--- a/roles/taca/templates/site_taca_sarek_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_delivery.yml.j2
@@ -43,27 +43,29 @@ deliver:
             - {{ ngi_softlinks }}/ACKNOWLEDGEMENTS.txt
             - <STAGINGPATH>
         -
-            - {{ ngi_softlinks }}/DELIVERY.README.SAREK.txt
-            - <STAGINGPATH>
+{% if site == "upps" %}
+            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report_data.zip
+            - <STAGINGPATH>/00-Reports/
             -
               required: True
-              no_digest_cache: True
         -
-{% if site == "upps" %}
-            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report*
+            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report.html
 {% elif site == "sthlm" %}
             - <ANALYSISPATH>/*multiqc_report.html
 {% endif %}
-{% if "_batch_" in config_dst %}
-            - <STAGINGPATH>/00-Reports/
-            -
-              required: False
-        -
-            - <ANALYSISPATHRESULTS>/Reports/MultiQC/*
-{% endif %}
             - <STAGINGPATH>/00-Reports/
             -
               required: True
+        -
+{% if "_batch_" in config_dst %}
+            - {{ ngi_softlinks }}/DELIVERY.README.SAREK.BATCH.txt
+{% else %}
+            - {{ ngi_softlinks }}/DELIVERY.README.SAREK.txt
+{% endif %}
+            - <STAGINGPATH>/
+            -
+              required: True
+              no_digest_cache: True
 {% if "sthlm" == site %}
     files_to_deliver:
         -
@@ -101,12 +103,20 @@ deliver:
             -
               required: True
         -
-            - <ANALYSISPATHRESULTS>/Reports/<SAMPLEID>/*
-            - <STAGINGPATHRESULTS>/Reports/<SAMPLEID>/
-            -
-              required: True
-        -
             - <ANALYSISPATHRESULTS>/VariantCalling/<SAMPLEID>/*
             - <STAGINGPATHRESULTS>/VariantCalling/
             -
               required: True
+{% if "_batch_" in config_dst %}
+        -
+            - <ANALYSISPATHRESULTS>/Reports/<SAMPLEID>/*
+            - <STAGINGPATHRESULTS>/Reports/<SAMPLEID>/
+            -
+              required: True
+{% else %}
+        -
+            - <ANALYSISPATHRESULTS>/Reports/*
+            - <STAGINGPATHRESULTS>/Reports
+            -
+              required: True
+{% endif %}

--- a/roles/taca/templates/site_taca_sarek_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_delivery.yml.j2
@@ -5,69 +5,33 @@ deliver:
     rootpath: "{{ ngi_pipeline_workdir }}"
     analysispath: <ROOTPATH>/ANALYSIS/<PROJECTID>
     stagingpath: <ROOTPATH>/DELIVERY/<PROJECTID>
+    stagingpathsample: <STAGINGPATH>/<SAMPLEID>
     operator: "{{ recipient_mail }}"
     hash_algorithm: md5
+{% if "_batch_" in config_dst %}
+    analysispathresults: <ANALYSISPATH>/SarekGermlineAnalysis/results
+{% else %}
+    analysispathresults: <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results
+{% endif %}
+{% if "sthlm" == site %}
+    datapath: <ROOTPATH>/DATA/<PROJECTID>
+    stagingpathhard: <ROOTPATH>/DELIVERY_HARD/<PROJECTID>
+    stagingpathresults: <STAGINGPATHSAMPLE>/01-SarekGermline-Results
+    save_meta_info: True
+    misc_files_to_deliver:
+        -
+            - <ANALYSISPATH>/reports/*
+            - <STAGINGPATH>/00-Reports
+{% endif %}
+
 {% if "upps" == site %}
+    stagingpathresults: <STAGINGPATHSAMPLE>/results
     files_to_deliver:
         -
             - <ANALYSISPATH>/seqreports/*
             - <STAGINGPATH>/00-Reports/SequenceQC/
-            - 
+            -
               required: True
-        -
-            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report.html
-            - <STAGINGPATH>/00-Reports/
-            - 
-              required: True
-        -
-            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report_data.zip
-            - <STAGINGPATH>/00-Reports/
-            - 
-              required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Annotation/<SAMPLEID>/*
-            - <STAGINGPATH>/<SAMPLEID>/results/Annotation/
-            - 
-              required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/pipeline_info/results_description.html
-            - <STAGINGPATH>/<SAMPLEID>/results/pipeline_info
-            - 
-              required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/pipeline_info/software_versions.csv
-            - <STAGINGPATH>/<SAMPLEID>/results/pipeline_info
-            - 
-              required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Preprocessing/TSV/duplicates_marked*<SAMPLEID>.tsv*
-            - <STAGINGPATH>/<SAMPLEID>/results/Preprocessing/TSV
-            - 
-              required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Preprocessing/<SAMPLEID>/DuplicatesMarked/*
-            - <STAGINGPATH>/<SAMPLEID>/results/Preprocessing/DuplicatesMarked
-            - 
-              required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Reports/*
-            - <STAGINGPATH>/<SAMPLEID>/results/Reports
-            - 
-              required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/VariantCalling/<SAMPLEID>/*
-            - <STAGINGPATH>/<SAMPLEID>/results/VariantCalling/
-            - 
-              required: True
-        -
-            - {{ ngi_softlinks }}/ACKNOWLEDGEMENTS.txt
-            - <STAGINGPATH>
-        -
-            - {{ ngi_softlinks }}/DELIVERY.README.SAREK.txt
-            - <STAGINGPATH>
-            - 
-              required: True
-              no_digest_cache: True
         -
             - {{ ngi_softlinks }}/apply_recalibration.sh
             - <STAGINGPATH>/01-Resources/
@@ -75,58 +39,74 @@ deliver:
               required: True
               no_digest_cache: True
 {% endif %}
-{% if "sthlm" == site %}
-    datapath: <ROOTPATH>/DATA/<PROJECTID>
-    stagingpathhard: <ROOTPATH>/DELIVERY_HARD/<PROJECTID>
-    files_to_deliver:
-        -
-            - <DATAPATH>/<SAMPLEID>/*/*
-            - <STAGINGPATH>/<SAMPLEID>/02-FASTQ
-            - required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Annotation/<SAMPLEID>/*
-            - <STAGINGPATH>/<SAMPLEID>/01-SarekGermline-Results/Annotation/
-            - required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/pipeline_info/results_description.html
-            - <STAGINGPATH>/<SAMPLEID>/01-SarekGermline-Results/pipeline_info
-            - required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/pipeline_info/software_versions.csv
-            - <STAGINGPATH>/<SAMPLEID>/01-SarekGermline-Results/pipeline_info
-            - required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Preprocessing/TSV/duplicates_marked*<SAMPLEID>.tsv*
-            - <STAGINGPATH>/<SAMPLEID>/01-SarekGermline-Results/Preprocessing/TSV
-            - required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Preprocessing/<SAMPLEID>/DuplicatesMarked/*
-            - <STAGINGPATH>/<SAMPLEID>/01-SarekGermline-Results/Preprocessing/DuplicatesMarked
-            - required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Preprocessing/<SAMPLEID>/Recalibrated/*
-            - <STAGINGPATH>/<SAMPLEID>/01-SarekGermline-Results/Preprocessing/Recalibrated
-            - required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/Reports/*
-            - <STAGINGPATH>/<SAMPLEID>/01-SarekGermline-Results/Reports
-            - required: True
-        -
-            - <ANALYSISPATH>/<SAMPLEID>/SarekGermlineAnalysis/results/VariantCalling/<SAMPLEID>/*
-            - <STAGINGPATH>/<SAMPLEID>/01-SarekGermline-Results/VariantCalling/
-            - required: True
-    misc_files_to_deliver:
         -
             - {{ ngi_softlinks }}/ACKNOWLEDGEMENTS.txt
             - <STAGINGPATH>
         -
             - {{ ngi_softlinks }}/DELIVERY.README.SAREK.txt
             - <STAGINGPATH>
+            -
+              required: True
+              no_digest_cache: True
         -
-            - <ANALYSISPATH>/reports/*
-            - <STAGINGPATH>/00-Reports
-        -
+{% if site == "upps" %}
+            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report*
+{% elif site == "sthlm" %}
             - <ANALYSISPATH>/*multiqc_report.html
-            - <STAGINGPATH>/00-Reports
-    save_meta_info: True
 {% endif %}
+{% if "_batch_" in config_dst %}
+            - <STAGINGPATH>/00-Reports/
+            -
+              required: False
+        -
+            - <ANALYSISPATHRESULTS>/Reports/MultiQC/*
+{% endif %}
+            - <STAGINGPATH>/00-Reports/
+            -
+              required: True
+{% if "sthlm" == site %}
+    files_to_deliver:
+        -
+            - <DATAPATH>/<SAMPLEID>/*/*
+            - <STAGINGPATHSAMPLE>/02-FASTQ
+            - required: True
+        -
+            - <ANALYSISPATHRESULTS>/Preprocessing/<SAMPLEID>/Recalibrated/*
+            - <STAGINGPATHRESULTS>/Preprocessing/Recalibrated
+            - required: True
+{% endif %}
+        -
+            - <ANALYSISPATHRESULTS>/Annotation/<SAMPLEID>/*
+            - <STAGINGPATHRESULTS>/Annotation/
+            -
+              required: True
+        -
+            - <ANALYSISPATHRESULTS>/pipeline_info/results_description.html
+            - <STAGINGPATHRESULTS>/pipeline_info
+            -
+              required: True
+        -
+            - <ANALYSISPATHRESULTS>/pipeline_info/software_versions.csv
+            - <STAGINGPATHRESULTS>/pipeline_info
+            -
+              required: True
+        -
+            - <ANALYSISPATHRESULTS>/Preprocessing/TSV/duplicates_marked*<SAMPLEID>.tsv*
+            - <STAGINGPATHRESULTS>/Preprocessing/TSV
+            -
+              required: True
+        -
+            - <ANALYSISPATHRESULTS>/Preprocessing/<SAMPLEID>/DuplicatesMarked/*
+            - <STAGINGPATHRESULTS>/Preprocessing/DuplicatesMarked
+            -
+              required: True
+        -
+            - <ANALYSISPATHRESULTS>/Reports/<SAMPLEID>/*
+            - <STAGINGPATHRESULTS>/Reports/<SAMPLEID>/
+            -
+              required: True
+        -
+            - <ANALYSISPATHRESULTS>/VariantCalling/<SAMPLEID>/*
+            - <STAGINGPATHRESULTS>/VariantCalling/
+            -
+              required: True

--- a/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
@@ -5,64 +5,66 @@ deliver:
     rootpath: "{{ ngi_pipeline_workdir }}"
     analysispath: <ROOTPATH>/ANALYSIS/<PROJECTID>
     stagingpath: <ROOTPATH>/DELIVERY/<PROJECTID>
+    stagingpathsample: <STAGINGPATH>/<SAMPLEID>
     operator: "{{ recipient_mail }}"
     hash_algorithm: md5
-
+    analysispathresults: <ANALYSISPATH>/SarekGermlineAnalysis/results
+    stagingpathresults: <STAGINGPATHSAMPLE>/results
     files_to_deliver:
         -
-          - <ANALYSISPATH>/results/multiqc_ngi/*multiqc_report.html
-          - <STAGINGPATH>/multiqc_ngi/
-          -
-            required: True
+            - <ANALYSISPATH>/seqreports/*
+            - <STAGINGPATH>/00-Reports/SequenceQC
+            -
+              required: True
         -
-          - <ANALYSISPATH>/results/multiqc_ngi/*multiqc_report_data.zip
-          - <STAGINGPATH>/multiqc_ngi/
-          -
-            required: True
+            - {{ ngi_softlinks }}/apply_recalibration.sh
+            - <STAGINGPATH>/01-Resources
+            -
+              required: True
+              no_digest_cache: True
         -
-          - <ANALYSISPATH>/results/Annotation/<SAMPLEID>/
-          - <STAGINGPATH>/Annotation/<SAMPLEID>/
-          -
-            required: True
+            - {{ ngi_softlinks }}/DELIVERY.README.SAREK.WES.md
+            - <STAGINGPATH>
+            -
+              required: True
+              no_digest_cache: True
         -
-          - <ANALYSISPATH>/results/pipeline_info/results_description.html
-          - <STAGINGPATH>/pipeline_info/
-          -
-            required: True
+            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report*
+            - <STAGINGPATH>/00-Reports
+            -
+              required: True
         -
-          - <ANALYSISPATH>/results/pipeline_info/software_versions.csv
-          - <STAGINGPATH>/pipeline_info/
-          -
-            required: True
+            - <ANALYSISPATHRESULTS>/Annotation/<SAMPLEID>/*
+            - <STAGINGPATHRESULTS>/Annotation/<SAMPLEID>
+            -
+              required: True
         -
-          - <ANALYSISPATH>/results/Preprocessing/TSV/duplicates_marked_<SAMPLEID>.tsv
-          - <STAGINGPATH>/Preprocessing/TSV
-          -
-            required: True
+            - <ANALYSISPATHRESULTS>/pipeline_info/results_description.html
+            - <STAGINGPATHRESULTS>/pipeline_info
+            -
+              required: True
         -
-          - <ANALYSISPATH>/results/Preprocessing/<SAMPLEID>/DuplicatesMarked/*
-          - <STAGINGPATH>/Preprocessing/<SAMPLEID>/DuplicatesMarked/
-          -
-            required: True
+            - <ANALYSISPATHRESULTS>/pipeline_info/software_versions.csv
+            - <STAGINGPATHRESULTS>/pipeline_info
+            -
+              required: True
         -
-          - <ANALYSISPATH>/results/Reports/<SAMPLEID>/
-          - <STAGINGPATH>/Reports/<SAMPLEID>/
-          -
-            required: True
+            - <ANALYSISPATHRESULTS>/Preprocessing/TSV/duplicates_marked*<SAMPLEID>.tsv*
+            - <STAGINGPATHRESULTS>/Preprocessing/TSV
+            -
+              required: True
         -
-          - <ANALYSISPATH>/results/VariantCalling/<SAMPLEID>/
-          - <STAGINGPATH>/VariantCalling/<SAMPLEID>/
-          -
-            required: True
+            - <ANALYSISPATHRESULTS>/Preprocessing/<SAMPLEID>/DuplicatesMarked/*
+            - <STAGINGPATHRESULTS>/Preprocessing/DuplicatesMarked/<SAMPLEID>
+            -
+              required: True
         -
-          - {{ ngi_softlinks }}/DELIVERY.README.SAREK.WES.md
-          - <STAGINGPATH>/
-          -
-            required: True
-            no_digest_cache: True
+            - <ANALYSISPATHRESULTS>/Reports/<SAMPLEID>/*
+            - <STAGINGPATHRESULTS>/Reports/<SAMPLEID>
+            -
+              required: True
         -
-          - {{ ngi_softlinks }}/apply_recalibration.sh
-          - <STAGINGPATH>/Resources/
-          -
-            required: True
-            no_digest_cache: True
+            - <ANALYSISPATHRESULTS>/VariantCalling/<SAMPLEID>/*
+            - <STAGINGPATHRESULTS>/VariantCalling/<SAMPLEID>
+            -
+              required: True

--- a/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_sarek_wes_delivery.yml.j2
@@ -29,7 +29,12 @@ deliver:
               required: True
               no_digest_cache: True
         -
-            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report*
+            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report.html
+            - <STAGINGPATH>/00-Reports
+            -
+              required: True
+        -
+            - <ANALYSISPATH>/multiqc_ngi/*multiqc_report_data.zip
             - <STAGINGPATH>/00-Reports
             -
               required: True


### PR DESCRIPTION
This adds TACA configs and a delivery readme (for Uppsala) that can be used for staging delivery of WGS analyses that have been run in a single nextflow process rather than with a separate process for each sample.

It also removes some of the redundancy between Sthlm and Uppsala in the config.