### PR TITLE
Fix dds-cli and arteria services incompatibility

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -9,6 +9,7 @@
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
 arteria_delivery_version: v2.6.3
 
+arteria_delivery_wrapper: "{{ arteria_service_config_root }}/arteria-delivery_wrapper.sh"
 
 arteria_service_name: arteria-delivery-ws
 

--- a/roles/arteria-delivery-ws/tasks/install.yml
+++ b/roles/arteria-delivery-ws/tasks/install.yml
@@ -25,9 +25,3 @@
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
     extra_args: "-U"
-
-- name: Deploy arteria-delivery wrapper
-  template:
-    src: arteria-delivery_wrapper.sh.j2
-    dest: "{{ arteria_delivery_wrapper }}"
-    mode: o+x

--- a/roles/arteria-delivery-ws/tasks/install.yml
+++ b/roles/arteria-delivery-ws/tasks/install.yml
@@ -1,7 +1,7 @@
 
 - name: create virtual python env for arteria-delivery
   shell: "conda create --name {{ arteria_service_name }} python=3.8"
-  args: 
+  args:
     creates: "{{ arteria_service_env_root }}"
 
 - name: get arteria-delivery from git
@@ -25,3 +25,9 @@
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
     extra_args: "-U"
+
+- name: Deploy arteria-delivery wrapper
+  template:
+    src: arteria-delivery_wrapper.sh.j2
+    dest: "{{ arteria_delivery_wrapper }}"
+    mode: o+x

--- a/roles/arteria-delivery-ws/tasks/install_config.yml
+++ b/roles/arteria-delivery-ws/tasks/install_config.yml
@@ -19,7 +19,7 @@
     dest: "{{ supervisord_conf }}"
     section: program:{{ arteria_service_name }}-{{ deployment_environment }}
     option: command
-    value: "{{ arteria_service_env_root }}/bin/delivery-ws --configroot={{ arteria_service_config_root }} --port={{ arteria_delivery_port }}"
+    value: "{{ arteria_delivery_wrapper }}"
     backup: no
 
 - name: modify uppsala's supervisord conf to autostart {{ arteria_service_name }}

--- a/roles/arteria-delivery-ws/tasks/install_config.yml
+++ b/roles/arteria-delivery-ws/tasks/install_config.yml
@@ -14,6 +14,12 @@
     src: delivery_logger.config.j2
     dest: "{{ arteria_service_config_root }}/logger.config"
 
+- name: Deploy arteria-delivery wrapper
+  template:
+    src: arteria-delivery_wrapper.sh.j2
+    dest: "{{ arteria_delivery_wrapper }}"
+    mode: o+x
+
 - name: modify uppsala's supervisord conf to start {{ arteria_service_name }}
   ini_file:
     dest: "{{ supervisord_conf }}"

--- a/roles/arteria-delivery-ws/templates/arteria-delivery_wrapper.sh.j2
+++ b/roles/arteria-delivery-ws/templates/arteria-delivery_wrapper.sh.j2
@@ -1,5 +1,5 @@
 #! /bin/bash -l
 
-module load dds-cli
+module load bioinfo-tools dds-cli
 
 {{ arteria_service_env_root }}/bin/delivery-ws --configroot={{ arteria_service_config_root }} --port={{ arteria_delivery_port }}"

--- a/roles/arteria-delivery-ws/templates/arteria-delivery_wrapper.sh.j2
+++ b/roles/arteria-delivery-ws/templates/arteria-delivery_wrapper.sh.j2
@@ -1,0 +1,5 @@
+#! /bin/bash -l
+
+module load dds-cli
+
+{{ arteria_service_env_root }}/bin/delivery-ws --configroot={{ arteria_service_config_root }} --port={{ arteria_delivery_port }}"

--- a/roles/setup_base_config/templates/sourceme_common.sh.j2
+++ b/roles/setup_base_config/templates/sourceme_common.sh.j2
@@ -7,9 +7,6 @@ export CHARON_BASE_URL={{ charon_base_url }}
 # Hopefully possible to remove dependency in a later version
 # module load bioinfo-tools piper/{{ piper_module_version }}
 
-# Load latest version of dds-cli
-module load bioinfo-tools dds-cli
-
 # Force English locale as e.g. some downstream scripts depend on the
 # pipeline outputing data with "." as decimal output instead of Swedish ",".
 export LC_ALL=en_US.UTF-8

--- a/roles/setup_base_config/templates/sourceme_site.sh.j2
+++ b/roles/setup_base_config/templates/sourceme_site.sh.j2
@@ -1,6 +1,9 @@
 # This file should be sourced from the user's local bash init files
 {% if site == "sthlm" %}
 # module load mover/1.0.0
+
+# Load latest version of dds-cli
+module load bioinfo-tools dds-cli
 {% endif %}
 
 # Unique settings per site
@@ -18,4 +21,3 @@ export PATH={{ sw_path }}:$PATH
 
 # Common settings shared for both sites
 source {{ ngi_pipeline_conf }}/{{ bash_env_common_script }}
-


### PR DESCRIPTION
We noticed a problem where some of our old arteria services wouldn't start. The issue was that site packages from the dds-cli installation was used instead of the ones installed in the service's own conda env. When dds-cli is loaded through the module system it sets `PYTHONPATH` to the site packages of the dds-cli installation, which makes python look there first when importing packages.

To avoid this problem we now instead load the dds-cli module for the service that needs it through a wrapper. We also leave it up to all Uppsala users to load the DDS module themselves since it has a risk of interfering with other environments. 

Tested on miarka3 with: 
```
ansible-playbook -i inventory.yml install.yml -t arteria-delivery,setup_base_config -e site=upps
ansible-playbook -i inventory.yml install.yml -t arteria-delivery,setup_base_config -e site=sthlm
```
