### PR TITLE
Update `arteria-delivery` to v3.0.0-rc1

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v2.6.4-rc1
+arteria_delivery_version: v3.0.0-rc1
 arteria_service_name: arteria-delivery-ws
 
 # These values will be appended with production and staging specific


### PR DESCRIPTION
We are removing support for mover from `arteria-delivery` in favor of DDS.

This new version also includes some significant refactoring of the code, so we need to test our delivery workflows thoroughly before releasing to production.