### PR TITLE
Remove single double quote in arteria-delivery wrapper

### DIFF
--- a/roles/arteria-delivery-ws/templates/arteria-delivery_wrapper.sh.j2
+++ b/roles/arteria-delivery-ws/templates/arteria-delivery_wrapper.sh.j2
@@ -2,4 +2,4 @@
 
 module load bioinfo-tools dds-cli
 
-{{ arteria_service_env_root }}/bin/delivery-ws --configroot={{ arteria_service_config_root }} --port={{ arteria_delivery_port }}"
+{{ arteria_service_env_root }}/bin/delivery-ws --configroot={{ arteria_service_config_root }} --port={{ arteria_delivery_port }}


### PR DESCRIPTION
A typo in the template for the arteria-delivery wrapper got through in the last release, this PR fixes that. 