### PR TITLE
Igenomes download

### DIFF
--- a/env_vars/site_all_env_production.yml
+++ b/env_vars/site_all_env_production.yml
@@ -5,6 +5,7 @@ deployment_version: "{{ branch_tag }}"
 root_path: "{{ deployment_target }}/{{ deployment_version }}"
 proj_root: "{{ static_proj_root }}"
 ngi_containers: "{{ deployment_remote_path }}/containers/"
+igenomes_dir: "{{ deployment_remote_path }}/igenomes"
 
 # ngi_pipeline
 charon_base_url: https://charon.scilifelab.se

--- a/env_vars/site_all_env_staging.yml
+++ b/env_vars/site_all_env_staging.yml
@@ -6,6 +6,7 @@ deployment_version: "{{ deployment_version_t ~ '-' ~ branch_name if branch_name 
 root_path: "{{ deployment_target }}/{{ deployment_version }}"
 proj_root: "{{ deployment_target }}/wildwest/"
 ngi_containers: "{{ deployment_remote_path }}/containers/"
+igenomes_dir: "{{ deployment_remote_path }}/igenomes"
 
 # statusdb
 orderportal_api_url: https://ngisweden.scilifelab.se/orders/api

--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -2,6 +2,7 @@
 # Empty placeholder that gets filled by env_vars and/or tasks/set_paths.yml
 root_path:
 ngi_containers:
+igenomes_dir:
 
 sw_path: "{{ root_path }}/sw"
 

--- a/install.yml
+++ b/install.yml
@@ -35,23 +35,18 @@
         files_matching: site_(all|{{ site }})_env_(all|{{ deployment_environment }}).yml$
       tags: always
 
-    - name: create {{ root_path }} folder and configure setgid
+    - name: create folder and configure setgid
       file:
-        path: "{{ root_path }}"
+        path: "{{ item }}"
         group: "{{ ngi_sw_group }}"
         state: directory
         recurse: no
         mode: g+rwXs,o=rX
       tags: always
-
-    - name: create {{ ngi_containers }} folder and configure setgid
-      file:
-        path: "{{ ngi_containers }}"
-        group: "{{ ngi_sw_group }}"
-        state: directory
-        recurse: no
-        mode: g+rwXs,o=rX
-      tags: always
+      with_items:
+        - root_path
+        - ngi_containers
+        - igenomes_dir
 
     - name: create {{ proj_root }} folder and configure setgid
       file:
@@ -120,21 +115,16 @@
 
     - name: set correct file permission for everything in the deployment
       file:
-        path: "{{ root_path }}"
+        path: "{{ item }}"
         group: "{{ ngi_sw_group }}"
         state: directory
         recurse: yes
         mode: g+rwX,o=rX
       tags: always
-
-    - name: make containers directory readable by anyone that can access miarka
-      file:
-        path: "{{ ngi_containers }}"
-        group: "{{ ngi_sw_group }}"
-        state: directory
-        recurse: yes
-        mode: g+rwX,o=rX
-      tags: always
+      with_items:
+        - root_path
+        - ngi_containers
+        - igenomes_dir
 
   post_tasks:
 

--- a/install.yml
+++ b/install.yml
@@ -35,19 +35,6 @@
         files_matching: site_(all|{{ site }})_env_(all|{{ deployment_environment }}).yml$
       tags: always
 
-    - name: create folder and configure setgid
-      file:
-        path: "{{ item }}"
-        group: "{{ ngi_sw_group }}"
-        state: directory
-        recurse: no
-        mode: g+rwXs,o=rX
-      tags: always
-      with_items:
-        - root_path
-        - ngi_containers
-        - igenomes_dir
-
     - name: create {{ proj_root }} folder and configure setgid
       file:
         path: "{{ proj_root }}"
@@ -57,6 +44,19 @@
         mode: g+rwXs,o-rwx
       when: deployment_environment in ["staging", "devel"]
       tags: always
+
+    - name: create folder and configure setgid
+      file:
+        path: "{{ item }}"
+        group: "{{ ngi_sw_group }}"
+        state: directory
+        recurse: no
+        mode: g+rwXs,o=rX
+      tags: always
+      with_items:
+        - "{{ root_path }}"
+        - "{{ ngi_containers }}"
+        - "{{ igenomes_dir }}"
 
     - name: initiate list of static folders that must be created on the target, after deployment
       set_fact:
@@ -122,9 +122,9 @@
         mode: g+rwX,o=rX
       tags: always
       with_items:
-        - root_path
-        - ngi_containers
-        - igenomes_dir
+        - "{{ root_path }}"
+        - "{{ ngi_containers }}"
+        - "{{ igenomes_dir }}"
 
   post_tasks:
 

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -58,3 +58,13 @@ nf_core_delivery_readmes:
     - DELIVERY.README.RNASEQ.md
   methylseq:
     - DELIVERY.README.METHYLSEQ.md
+
+awscli_version: 1.27.5
+aws_igenomes_repo: https://github.com/ewels/AWS-iGenomes.git
+aws_igenomes_commit: dda1d928fdb0d018aabbf91ac6ce8e153b699991
+aws_igenomes_dest: "{{ sw_path }}/AWS-iGenomes"
+igenomes:
+  - genome: Homo_sapiens
+    source: GATK
+    build: GRCh38
+    type: gatk

--- a/roles/nf-core/tasks/igenomes.yml
+++ b/roles/nf-core/tasks/igenomes.yml
@@ -1,0 +1,19 @@
+
+- name: get AWS-igenomes from git
+  git:
+    repo: "{{ aws_igenomes_repo }}"
+    dest: "{{ aws_igenomes_dest }}"
+    version: "{{ aws_igenomes_commit }}"
+
+- name: download iGenome {{ item.genome }}/{{ item.source }}/{{ item.build }}:{{ item.type }}
+  command: "{{ aws_igenomes_dest }}/aws-igenomes.sh 
+    -g {{ item.genome }}
+    -s {{ item.source }}
+    -b {{ item.build }}
+    -t {{ item.type }}
+    -q"
+  environment: "{{ nf_core_vars }}"
+  args:
+    chdir: "{{ igenomes_dir }}"
+    creates: "{{ igenomes_dir }}/references/{{ item.genome }}/{{ item.source }}/{{ item.build }}"
+  with_items: "{{ igenomes }}"

--- a/roles/nf-core/tasks/igenomes.yml
+++ b/roles/nf-core/tasks/igenomes.yml
@@ -4,16 +4,24 @@
     repo: "{{ aws_igenomes_repo }}"
     dest: "{{ aws_igenomes_dest }}"
     version: "{{ aws_igenomes_commit }}"
+    force: yes
 
-- name: download iGenome {{ item.genome }}/{{ item.source }}/{{ item.build }}:{{ item.type }}
+- name: set permissions to the seqreports data path
+  file:
+    path: "{{ aws_igenomes_dest }}/aws-igenomes.sh"
+    mode: +x
+
+- name: download iGenome
   command: "{{ aws_igenomes_dest }}/aws-igenomes.sh 
     -g {{ item.genome }}
     -s {{ item.source }}
     -b {{ item.build }}
-    -t {{ item.type }}
+    {{ ['-t', item.type] | join if type else '' }}
     -q"
-  environment: "{{ nf_core_vars }}"
+  environment:
+    PATH: "{{ nf_core_env }}/bin"
   args:
     chdir: "{{ igenomes_dir }}"
     creates: "{{ igenomes_dir }}/references/{{ item.genome }}/{{ item.source }}/{{ item.build }}"
-  with_items: "{{ igenomes }}"
+  with_items:
+    - "{{ igenomes }}"

--- a/roles/nf-core/tasks/main.yml
+++ b/roles/nf-core/tasks/main.yml
@@ -19,6 +19,7 @@
     silva_zip: "{{ item.silva_zip | default('') }}"
     container_dir: "{{ ngi_containers }}/{{ item.container_dir | default(item.name) }}"
   with_items: "{{ pipelines }}"
+  tags: pipelines
 
 # Setup iGenomes
 - name: setup iGenomes

--- a/roles/nf-core/tasks/main.yml
+++ b/roles/nf-core/tasks/main.yml
@@ -4,7 +4,7 @@
   register: "nfcore_envs"
 
 - name: Setup {{ nf_core_env_name }} virtual env with python3 and nf-core v{{ nf_core_version }}
-  command: "conda create -n {{ nf_core_env_name }} -c conda-forge -c bioconda -c anaconda python={{ python3_version }} nf-core={{ nf_core_version }} nextflow={{ nextflow_version_tag }}"
+  command: "conda create -n {{ nf_core_env_name }} -c conda-forge -c bioconda -c anaconda python={{ python3_version }} nf-core={{ nf_core_version }} nextflow={{ nextflow_version_tag }} awscli={{ awscli_version }}"
   when: not nf_core_env_name in nfcore_envs.stdout|split
 
 # Setup pipelines
@@ -19,6 +19,11 @@
     silva_zip: "{{ item.silva_zip | default('') }}"
     container_dir: "{{ ngi_containers }}/{{ item.container_dir | default(item.name) }}"
   with_items: "{{ pipelines }}"
+
+# Setup iGenomes
+- name: setup iGenomes
+  include_tasks: igenomes.yml
+  tags: igenomes
 
 - name: Deploy script for softlinking delivery Readmes
   template:

--- a/roles/nf-core/templates/site.config.j2
+++ b/roles/nf-core/templates/site.config.j2
@@ -1,6 +1,7 @@
 
 singularity.libraryDir = '{{ nf_core_vars.NXF_SINGULARITY_LIBRARYDIR }}'
 singularity.cacheDir = '{{ nf_core_vars.NXF_SINGULARITY_CACHEDIR }}'
+igenomes_base = '{{ igenomes_dir }}/references'
 
 {% if pipeline == 'methylseq' %}
 

--- a/roles/nf-core/templates/site.config.j2
+++ b/roles/nf-core/templates/site.config.j2
@@ -1,7 +1,10 @@
 
 singularity.libraryDir = '{{ nf_core_vars.NXF_SINGULARITY_LIBRARYDIR }}'
 singularity.cacheDir = '{{ nf_core_vars.NXF_SINGULARITY_CACHEDIR }}'
-igenomes_base = '{{ igenomes_dir }}/references'
+
+/* this is commented out by default in order to not override the default uppmax path
+   if necessary to use the custom location, uncomment this parameter */
+//igenomes_base = '{{ igenomes_dir }}/references'
 
 {% if pipeline == 'methylseq' %}
 

--- a/sync.yml
+++ b/sync.yml
@@ -23,6 +23,7 @@
           paths:
             - "{{ root_path }}"
             - "{{ ngi_containers }}"
+            - "{{ igenomes_dir }}"
           recurse: yes
           excludes: "{{ exclude_pattern }}"
           file_type: any
@@ -87,7 +88,7 @@
       with_items:
           - "{{ hostvars['deploy']['root_path'] | replace(deployment_remote_path, deployment_remote_path + '/.') }}"
           - "{{ hostvars['deploy']['ngi_containers'] | replace(deployment_remote_path, deployment_remote_path + '/.') }}"
-
+          - "{{ hostvars['deploy']['igenomes_dir'] | replace(deployment_remote_path, deployment_remote_path + '/.') }}"
 
     - name: create or move the latest symlink to {{ deployment_version }}
       file:


### PR DESCRIPTION
This adds code for downloading references from iGenomes during deployment

In general, we would probably prefer to keep these off `/vulpes/ngi` and under management by Uppmax but there may be instances where it would be convenient to be able to retrieve and use references ourselves.

Currently, the most comprehensive reference set for Sarek v3.0.2 seems to be GRCh38 provided by GATK and this is not available in the current igenomes  resource hosted by Uppmax.
