### PR TITLE
construct command for pulling snpeff and vep cached containers

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -18,14 +18,17 @@ pipelines:
     container_dir: "{{ biocontainers_dirname }}"
   - name: sarek
     release: "{{ sarek_tag }}"
+    container_dir: "{{ biocontainers_dirname }}"
     pipeline_specific_containers:
-      - sarekvep
-      - sareksnpeff
+      - vep-106.1
+      - snpeff-5.1
     pipeline_genomes:
       - GRCh38
       - GRCh37
       - GRCm38
+      - GRCm39
       - CanFam3.1
+      - WBcel235
   - name: methylseq
     release: 1.6.1
   - name: ampliseq

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -29,11 +29,11 @@
     creates: "{{ sw_path }}/{{ pipeline }}"
 
 - name: pull pipeline-specific images for {{ pipeline }} v{{ release }}
-  command: "singularity pull --name nfcore-{{ container.0 }}-{{ release }}.{{ container.1 }}.img {{ nf_core_container_repo }}/{{ container.0 }}:{{ release }}.{{ container.1 }}"
+  command: "singularity pull --name nfcore-{{ container.0 }}.{{ container.1 }}.img {{ nf_core_container_repo }}/{{ container.0 | replace('-', ':', 1) }}.{{ container.1 }}"
   environment: "{{ nf_core_vars }}"
   args:
     chdir: "{{ container_dir }}"
-    creates: "{{ container_dir }}/nfcore-{{ container.0 }}-{{ release }}.{{ container.1 }}.img"
+    creates: "{{ container_dir }}/nfcore-{{ container.0 }}.{{ container.1 }}.img"
   ignore_errors: true
   with_nested:
     - "{{ pipeline_specific_containers }}"


### PR DESCRIPTION
With newer versions of Sarek (> v3?), the names of the snpeff and vep containers have changed to include the actual version of e.g. snpeff instead of the Sarek version. Therefore, it is necessary to update the command for pulling them accordingly. 

AFAIK, there is no way to have nf-core download these automatically along with the pipeline itself.
