### PR TITLE
Update readme links for sthlm

### DIFF
--- a/roles/taca/templates/site_app_specific_delivery.yml.j2
+++ b/roles/taca/templates/site_app_specific_delivery.yml.j2
@@ -32,11 +32,19 @@ deliver:
             - <STAGINGPATH>/01-QC-Results
             - required: True
 {% elif "fastq" == item.item_type %}
+{% if "sthlm" == site %}
+            - DELIVERY.README.RAW_DATA.txt
+{% else %}
             - {{ ngi_softlinks }}/DELIVERY.README.RAW_DATA.txt
+{% endif %}
             - <STAGINGPATH>
 {% endif %}
         -
+{% if "sthlm" == site %}
+            - ACKNOWLEDGEMENTS.txt
+{% else %}
             - {{ ngi_softlinks }}/ACKNOWLEDGEMENTS.txt
+{% endif %}
             - <STAGINGPATH>
         -
             - <ANALYSISPATH>/reports/*


### PR DESCRIPTION
We noticed some irregularities in the md5 files generated for fastq deliveries. This should hopefully fix it.