### PR TITLE
Revert unnecessary changes and update taca-ngi-pipeline

### DIFF
--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 taca_ngi_repo: https://github.com/SciLifeLab/taca-ngi-pipeline.git
 taca_ngi_dest: "{{ sw_path }}/taca-ngi-pipeline"
-taca_ngi_version: 4bc5b87ab648254887fb5ef8dd815e73c36bc554
+taca_ngi_version: 4370e2aaf0979bd6ebd83cb38c851860e8b7cd3f
 
 flowcell_parser_repo: https://github.com/SciLifeLab/flowcell_parser.git
 flowcell_parser_dest: "{{ sw_path }}/flowcell_parser"

--- a/roles/taca/templates/site_app_specific_delivery.yml.j2
+++ b/roles/taca/templates/site_app_specific_delivery.yml.j2
@@ -32,19 +32,11 @@ deliver:
             - <STAGINGPATH>/01-QC-Results
             - required: True
 {% elif "fastq" == item.item_type %}
-{% if "sthlm" == site %}
-            - DELIVERY.README.RAW_DATA.txt
-{% else %}
             - {{ ngi_softlinks }}/DELIVERY.README.RAW_DATA.txt
-{% endif %}
             - <STAGINGPATH>
 {% endif %}
         -
-{% if "sthlm" == site %}
-            - ACKNOWLEDGEMENTS.txt
-{% else %}
             - {{ ngi_softlinks }}/ACKNOWLEDGEMENTS.txt
-{% endif %}
             - <STAGINGPATH>
         -
             - <ANALYSISPATH>/reports/*


### PR DESCRIPTION
The md5 checksum file issues were handled in taca-ngi-pipeline, so reverting the config changes.