### PR TITLE
update ngi_pipeline version

### DIFF
--- a/roles/ngi_pipeline/defaults/main.yml
+++ b/roles/ngi_pipeline/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ngi_pipeline_repo: https://github.com/NationalGenomicsInfrastructure/ngi_pipeline.git
 ngi_pipeline_dest: "{{ sw_path }}/ngi_pipeline"
-ngi_pipeline_version: 16d3ea485877c48d0262ac1642b15802fe1ce4a7
+ngi_pipeline_version: b8b20c9cb7e53d852842336e2c299d640d6cfce1
 
 ngi_pipeline_log: "{{ ngi_log_path }}/ngi_pipeline.log"
 ngi_pipeline_db_path: "{{ ngi_pipeline_path }}/db"


### PR DESCRIPTION
This updates the ngi_pipeline version in the `bimonthly` branch and thus brings it in line with the `monthly` branch. This is to get rid of the PyVCF requirement, which breaks installation for virtualenvs with setuptools > 57.5.0.