### PR TITLE
remove network arguments for kong singularity

### DIFF
--- a/roles/tarzan/templates/start_kong.sh.j2
+++ b/roles/tarzan/templates/start_kong.sh.j2
@@ -8,7 +8,6 @@ singularity instance start \
 --bind "{{ tarzan_cert_file }}:{{ tarzan_singularity_container_cert_file }}" \
 --bind "{{ tarzan_key_file }}:{{ tarzan_singularity_container_key_file }}" \
 --bind "{{ tarzan_log_dir }}:{{ tarzan_singularity_container_log_dir }}" \
---network-args "portmap={{ tarzan_port }}:{{ tarzan_singularity_container_port }}/tcp" \
 {{ tarzan_singularity_image_file_dest }} {{ tarzan_singularity_container_name }}
 
 singularity exec instance://{{ tarzan_singularity_container_name }} kong start --conf {{ tarzan_singularity_container_server_conf_file }}


### PR DESCRIPTION
Network arguments were apparently unused and with the latest update of singularity, they would break the command. Removing them fixes the problems.