### PR TITLE
Update arteria-delivery to v3.0.1-rc2

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v3.0.0-rc2
+arteria_delivery_version: v3.0.1-rc2
 
 arteria_delivery_wrapper: "{{ arteria_service_config_root }}/arteria-delivery_wrapper.sh"
 


### PR DESCRIPTION
Update arteria-delivery to v3.0.1-rc2

This versions fixes relatively small things and should be validated easily (https://github.com/arteria-project/arteria-delivery/releases/tag/v3.0.1-rc2).