### PR TITLE
Add scilife logo back to multiqc, fix bug in ngi_reports

### DIFF
--- a/roles/multiqc/defaults/main.yml
+++ b/roles/multiqc/defaults/main.yml
@@ -4,4 +4,4 @@ multiqc_version: "v1.14"
 
 multiqc_ngi_repo: https://github.com/NationalGenomicsInfrastructure/MultiQC_NGI.git
 multiqc_ngi_dest: "{{ sw_path }}/multiqc_ngi"
-multiqc_ngi_version: "0.6.7"
+multiqc_ngi_version: "0.6.8"

--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ngi_reports_repo: https://github.com/NationalGenomicsInfrastructure/ngi_reports.git
 ngi_reports_dest: "{{ sw_path }}/ngi_reports"
-ngi_reports_version: 7f7fbb3e5c9dda9779062b083f9f766430303fd1
+ngi_reports_version: 5f4b5ee054dc8389223ce152561febc6f1e4e60d
 ngi_reports_log: "{{ ngi_log_path }}/ngi_reports.log"
 
 ngi_visual_repo: https://github.com/NationalGenomicsInfrastructure/ngi_visualizations.git


### PR DESCRIPTION
* The Scilifelab logo was removed from Multiqc v1.14, so I've moved it to multiqc_ngi
* A few minor bugs with handling corner cases were fixed in ngi_reports.  