### PR TITLE
seqreports: add seqreports service to kong

### DIFF
--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -34,6 +34,14 @@ services:
       - /arteria_archive/verify
       strip_path: true
 
+  - name: arteria_sequencing_reports
+    host: localhost
+    port: {{ seqreport_service_port }}
+    routes:
+    - paths:
+      - /seqreports
+      strip_path: true
+
 plugins:
   - name: key-auth
     config:


### PR DESCRIPTION
Adds the seqreports service to the kong proxy.