### PR TITLE
Include staging path for DDS runfolder deliveries

### DIFF
--- a/roles/taca/templates/site_taca_runfolder_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_runfolder_delivery.yml.j2
@@ -4,6 +4,7 @@ log:
 deliver:
     rootpath: "{{ proj_root }}/{{ uppmax_project }}"
     datapath: <ROOTPATH>/incoming
+    stagingpath: <ROOTPATH>/DELIVERY/<PROJECTID>
     stagingpathhard: <ROOTPATH>/nobackup/NGI/DELIVERY_HARD/<PROJECTID>
     operator: "{{ recipient_mail }}"
 {% if "sthlm" == site %}

--- a/roles/taca/templates/site_taca_runfolder_delivery.yml.j2
+++ b/roles/taca/templates/site_taca_runfolder_delivery.yml.j2
@@ -4,7 +4,7 @@ log:
 deliver:
     rootpath: "{{ proj_root }}/{{ uppmax_project }}"
     datapath: <ROOTPATH>/incoming
-    stagingpath: <ROOTPATH>/DELIVERY/<PROJECTID>
+    stagingpath: <ROOTPATH>/nobackup/NGI/DELIVERY/<PROJECTID>
     stagingpathhard: <ROOTPATH>/nobackup/NGI/DELIVERY_HARD/<PROJECTID>
     operator: "{{ recipient_mail }}"
 {% if "sthlm" == site %}


### PR DESCRIPTION
Should fix issue with using TACA to deliver runfolders with DDS.