### PR TITLE
Tarzan: SubjectAltName in certificate

### DIFF
--- a/env_vars/site_upps_env_production.yml
+++ b/env_vars/site_upps_env_production.yml
@@ -10,3 +10,6 @@ project_path: "{{ ngi_pipeline_workdir }}/DELIVERY"
 staging_path: "{{ ngi_pipeline_workdir }}/DELIVERY/arteria-staged"
 db_path: "{{ static_ngi_pipeline_path }}/db/arteria/{{ deployment_environment }}"
 delivery_links: "{{ static_ngi_pipeline_nobackup }}/arteria/{{ deployment_environment }}/delivery_project_links"
+
+# tarzan
+tarzan_host_name: miarka1.uppmax.uu.se

--- a/env_vars/site_upps_env_staging.yml
+++ b/env_vars/site_upps_env_staging.yml
@@ -13,3 +13,6 @@ delivery_links: "{{ static_ngi_pipeline_nobackup }}/arteria/{{ deployment_enviro
 
 # taca
 snic_api_url: https://disposer.c3se.chalmers.se/supr-test/api
+
+# tarzan
+tarzan_host_name: miarka2.uppmax.uu.se

--- a/roles/tarzan/README.md
+++ b/roles/tarzan/README.md
@@ -23,11 +23,13 @@ Set `tarzan_singularity_image_sha1` in `defaults/main.yml` to this value.
 
 It is recommended to have separate certificates for staging and production.
 
-On the node running Kong, run: `openssl req -x509 -newkey rsa:2048 -keyout tarzan_key.pem -out tarzan_cert.pem -days 1460 -nodes -subj '/CN=miarka2.uppmax.uu.se'`. (Or `CN=miarka1.uppmax.uu.se` for production.)
+On the node running Kong, run:
+```
+openssl req -config <tarzan_conf_dir>/tarzan_cert_config.txt -newkey rsa:2048 -nodes -keyout tarzan_key.pem -x509 -days 1460 -out tarzan_cert.pem
+```
 
 Move the generated certificate and key to the paths defined by `tarzan_cert_file` and `tarzan_key_file` in `env_vars/site_[site]_env_[environment].yml`.
 
-One can then add the contents of tarzan_cert.pem to the client's CA bundle to get rid of certificate warnings. Some clients (like Stackstorm) use the Mozilla CA bundle in the Python library requests, which can usually be found under a path similar to `.../python2.7/site-packages/requests/cacert.pem`.
 # Authentication
 
 The Kong `key-auth` plugin is enabled on all routes.

--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -9,8 +9,12 @@ tarzan_log_dir:  "{{ tarzan_proj_dir }}/logs"
 
 # Config files
 tarzan_server_conf_file: "{{ tarzan_conf_dir }}/kong.conf"
+tarzan_cert_conf_file: "{{ tarzan_conf_dir }}/tarzan_cert_config.txt"
 tarzan_entity_conf_file: "{{ tarzan_conf_dir }}/kong.yml"
 tarzan_singularity_def_file: "{{ tarzan_conf_dir }}/kong.def"
+
+# Host name (used in cert config)
+tarzan_host_name: "miarka1.uppmax.uu.se"
 
 # Scripts
 tarzan_start_script: "{{ tarzan_conf_dir }}/start_kong.sh"

--- a/roles/tarzan/meta/main.yml
+++ b/roles/tarzan/meta/main.yml
@@ -1,4 +1,4 @@
 dependencies:
-  - { role: setup_base_config, tags: setup_base_config,
-      role: func_accounts, tags: func_accounts}
+  - { role: setup_base_config, tags: setup_base_config }
+  - { role: func_accounts, tags: func_accounts }
 

--- a/roles/tarzan/meta/main.yml
+++ b/roles/tarzan/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
-  - { role: setup_base_config, tags: setup_base_config }
+  - { role: setup_base_config, tags: setup_base_config,
+      role: func_accounts, tags: func_accounts}
 

--- a/roles/tarzan/tasks/install_tarzan.yml
+++ b/roles/tarzan/tasks/install_tarzan.yml
@@ -19,6 +19,11 @@
     src: "kong.yml.j2"
     dest: "{{ tarzan_entity_conf_file }}"
 
+- name: deploy cert config file for kong
+  template:
+    src: "tarzan_cert_config.txt.j2"
+    dest: "{{ tarzan_cert_conf_file }}"
+
 - name: deploy kong start script
   template:
     src: "start_kong.sh.j2"

--- a/roles/tarzan/templates/tarzan_cert_config.txt.j2
+++ b/roles/tarzan/templates/tarzan_cert_config.txt.j2
@@ -1,0 +1,16 @@
+[ req ]
+prompt = no
+distinguished_name = server_distinguished_name
+x509_extensions = v3_req
+
+[ server_distinguished_name ]
+commonName = {{ tarzan_host_name }}
+
+[ v3_req ]
+basicConstraints = CA:TRUE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment,keyCertSign
+subjectAltName = @alternate_names
+
+[ alternate_names ]
+
+DNS.1 = {{ tarzan_host_name }}


### PR DESCRIPTION
This PR updates the instructions on how to create certificates for Tarzan/Kong. It also adds a step that creates a config that is used when creating the certificate. 

Why?
The certificate now contains SubjectAltName and not only CommonName. The reason for this change is that urllib3 has dropped support for CommonName only: https://github.com/urllib3/urllib3/releases/tag/2.0.0

Other:
I added the func_accounts as a dependency since I noticed the tarzan role assumes that a crontab has been created. 

Validation:
I have tested generating a certificate in staging env and it works. I also successfully deployed these changed in the dev env on miarka3. 

Risk analysis: 
These changes only concern docs and creating a standalone file for a manual step. This should not interfere with the other operations.