### PR TITLE
Set Nextflow singularity cache dir

### DIFF
--- a/roles/arteria-sequencing-report-ws/templates/seqreport_app.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/seqreport_app.config.j2
@@ -18,6 +18,7 @@ nextflow_config:
     environment:
         NXF_TEMP: {{ nextflow_env.NXF_TEMP }}
         NXF_WORK: {{ nextflow_env.NXF_WORK }}
+        NXF_SINGULARITY_CACHEDIR: "{{ ngi_containers }}/seqreports"
     # Note that in the parameters section it is possible to do variable
     # subsitution on the following variables.
     # loading the config.


### PR DESCRIPTION
When deploying the service, the `NXF_SINGULARITY_CACHEDIR` variable is used to cache the singularity images. The same location should be used when running seqreports jobs