### PR TITLE
Update CheckQC

### DIFF
--- a/files/checkqc.config
+++ b/files/checkqc.config
@@ -1,4 +1,4 @@
-# Adapted from https://github.com/Molmed/checkQC/blob/v3.7.0/checkQC/default_config/config.yaml
+# Adapted from https://github.com/Molmed/checkQC/blob/v3.8.2/checkQC/default_config/config.yaml
 # For information about config usage, see http://checkqc.readthedocs.io/en/latest/#configuration-file
 
 # Use this section to provide configuration options to the parsers
@@ -44,7 +44,7 @@ hiseq2500_rapidhighoutput_v4:
   100-111:
     handlers:
       - name: ClusterPFHandler
-        warning: 180 
+        warning: 180
         error: unknown
       - name: Q30Handler
         warning: 80
@@ -323,6 +323,166 @@ novaseq_S4:
       - name: ReadsPerSampleHandler
         warning: unknown
         error: 1500
+
+novaseqxplus_1.5B:
+  51:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 800
+        error: unknown
+      - name: Q30Handler
+        warning: 90 
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 600
+  101:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 800
+        error: unknown
+      - name: Q30Handler
+        warning: 85
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 2
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 600
+  151:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 800
+        error: unknown
+      - name: Q30Handler
+        warning: 85
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 5
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 600
+
+novaseqxplus_10B:
+  51:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1250
+        error: unknown
+      - name: Q30Handler
+        warning: 90
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 937.5
+  101:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1250
+        error: unknown
+      - name: Q30Handler
+        warning: 85
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 2
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 937.5
+  151:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1250
+        error: unknown
+      - name: Q30Handler
+        warning: 85
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False 
+        warning: 5
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 937.5
+
+novaseqxplus_25B:
+  151:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 3250
+        error: unknown
+      - name: Q30Handler
+        warning: 85
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 5
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 2437.5
+
+miseq_nano_v2:
+  151:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1
+        error: unknown
+      - name: Q30Handler
+        warning: 80
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 2
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 7.5
+  251:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 5
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 7.5
+
+miseq_micro_v2:
+  151:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 4
+        error: unknown
+      - name: Q30Handler
+        warning: 80
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 2
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 7.5
 
 miseq_v2:
   51:

--- a/roles/arteria-checkqc-ws/defaults/main.yml
+++ b/roles/arteria-checkqc-ws/defaults/main.yml
@@ -2,4 +2,4 @@ arteria_service_name: arteria-checkqc-ws
 arteria_checkqc_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 checkqc_repo: https://github.com/Molmed/checkQC.git
-checkqc_version: v3.8.2
+checkqc_version: v4.0.0-rc2


### PR DESCRIPTION
The recent update of the NovaSeqX+ instrument requires some adjustments in CheckQC.

This PR updates CheckQC to v4.0.0-rc2

Validation should include running `ngi_uu_workflow` on the test NovaSeqX+ runfolder.