### PR TITLE
Bump seqencing-reports-service to v1.4.2-rc1

### DIFF
--- a/roles/arteria-sequencing-report-ws/defaults/main.yml
+++ b/roles/arteria-sequencing-report-ws/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 seqreport_service_repo: https://github.com/arteria-project/sequencing-report-service.git
-seqreport_service_version: v1.4.1
+seqreport_service_version: v1.4.2-rc1
 
 arteria_service_name: arteria-sequencing-report-ws
 arteria_sequencing_report_wrapper: "{{ arteria_service_config_root }}/arteria_sequencing_report_wrapper.sh"


### PR DESCRIPTION
This fixes a NovaSeq X Plus issue introduced when upgrading the instrument. 