### PR TITLE
Update CheckQC and Seqreports

### DIFF
--- a/roles/arteria-checkqc-ws/defaults/main.yml
+++ b/roles/arteria-checkqc-ws/defaults/main.yml
@@ -2,4 +2,4 @@ arteria_service_name: arteria-checkqc-ws
 arteria_checkqc_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 checkqc_repo: https://github.com/Molmed/checkQC.git
-checkqc_version: v4.0.0-rc2
+checkqc_version: v4.0.0

--- a/roles/arteria-sequencing-report-ws/defaults/main.yml
+++ b/roles/arteria-sequencing-report-ws/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 seqreport_service_repo: https://github.com/arteria-project/sequencing-report-service.git
-seqreport_service_version: v1.4.2-rc1
+seqreport_service_version: v1.4.2
 
 arteria_service_name: arteria-sequencing-report-ws
 arteria_sequencing_report_wrapper: "{{ arteria_service_config_root }}/arteria_sequencing_report_wrapper.sh"


### PR DESCRIPTION
Validation of CheckQC v4.0.0 and sequencing-report-service v1.4.2 succeeded. This PR sets their respective versions to the latest release instead of the release candidate.