### PR TITLE
Set log level to INFO for arteria-checksum

### DIFF
--- a/roles/arteria-checksum-ws/templates/checksum_logger.config.j2
+++ b/roles/arteria-checksum-ws/templates/checksum_logger.config.j2
@@ -16,7 +16,7 @@ handlers:
 
     file_handler:
         class: logging.handlers.RotatingFileHandler
-        level: WARNING  # By default set to WARNING, but can be changed on runtime
+        level: INFO
         formatter: simple
         filename: "{{ arteria_checksum_service_log }}"
         maxBytes: 10485760  # 10MB


### PR DESCRIPTION
Due to recent connectivity issues with the service, we would like it to be more verbose. 