### PR TITLE
include nf-core pipeline version tag in path

### DIFF
--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -47,7 +47,10 @@ ngi_pipeline_conf: "{{ root_path }}/conf/"
 ngi_resources: "{{ root_path }}/resources/"
 
 sarek_tag: "2.7"
-sarek_dest: "{{ sw_path }}/sarek"
+sarek_dest: "{{ sw_path }}/sarek/{{ sarek_tag | replace('.', '_') }}"
+
+rnaseq_tag: "3.3"
+rnaseq_dest: "{{ sw_path }}/rnaseq/{{ rnaseq_tag | replace('.', '_') }}"
 
 demultiplex_tag: "1.4.1"
 

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -15,7 +15,7 @@ nf_core_vars:
 biocontainers_dirname: biocontainers
 pipelines:
   - name: rnaseq
-    release: 3.3
+    release: "{{ rnaseq_tag }}"
     container_dir: "{{ biocontainers_dirname }}"
   - name: sarek
     release: "{{ sarek_tag }}"

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -52,7 +52,7 @@
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/{{ bash_env_script }}"
     line: >
-          alias {{ pipeline }}='nextflow run {{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') }}/workflow/
+          alias {{ pipeline }}='nextflow run {{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') }}/
           -profile uppmax \
           -c {{ ngi_pipeline_conf }}/nextflow_miarka_{{ site }}.config \
           -c {{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config'

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -27,7 +27,7 @@
   ignore_errors: true
   args:
     chdir: "{{ sw_path }}"
-    creates: "{{ sw_path }}/{{ pipeline }}"
+    creates: "{{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') }}"
 
 - name: pull pipeline-specific images for {{ pipeline }} v{{ release }}
   command: "singularity pull --name nfcore-{{ container.0 }}-{{ release }}.{{ container.1 }}.img {{ nf_core_container_repo }}/{{ container.0 }}:{{ release }}.{{ container.1 }}"
@@ -51,7 +51,7 @@
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/{{ bash_env_script }}"
     line: >
-          alias {{ pipeline }}='nextflow run {{ sw_path }}/{{ pipeline }}/workflow/
+          alias {{ pipeline }}='nextflow run {{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') }}/workflow/
           -profile uppmax \
           -c {{ ngi_pipeline_conf }}/nextflow_miarka_{{ site }}.config \
           -c {{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config'

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -18,6 +18,7 @@
   command: >
     nf-core -v
     download {{ pipeline }}
+    -d
     --compress none
     --outdir {{ sw_path }}/{{ pipeline }}
     --revision {{ release }}

--- a/roles/ngi_pipeline/templates/miarka_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/miarka_ngi_config.yaml.j2
@@ -75,7 +75,7 @@ analysis:
             analysis_engine: ngi_pipeline.engines.qc_ngi
         RNA-seq:
             analysis_engine: ngi_pipeline.engines.rna_ngi
-            ngi_nf_path: {{ sw_path }}/rnaseq/workflow/
+            ngi_nf_path: {{ rnaseq_dest }}/workflow/
             sthlm_ngi_conf: {{ rna_seq_conf }}
             upps_ngi_conf: {{ rna_seq_conf }}
         wgs_germline:

--- a/roles/ngi_pipeline/templates/miarka_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/miarka_ngi_config.yaml.j2
@@ -33,7 +33,7 @@ piper:
     gatk_key: "{{ ngi_resources }}/piper/{{ gatk_key }}"
 
 sarek:
-    command: {{ sarek_dest }}/workflow/main.nf
+    command: {{ sarek_dest }}/main.nf
     tools:
       - haplotypecaller
       - snpeff
@@ -75,7 +75,7 @@ analysis:
             analysis_engine: ngi_pipeline.engines.qc_ngi
         RNA-seq:
             analysis_engine: ngi_pipeline.engines.rna_ngi
-            ngi_nf_path: {{ rnaseq_dest }}/workflow/
+            ngi_nf_path: {{ rnaseq_dest }}/
             sthlm_ngi_conf: {{ rna_seq_conf }}
             upps_ngi_conf: {{ rna_seq_conf }}
         wgs_germline:

--- a/roles/snpseq-metadata-service/defaults/main.yml
+++ b/roles/snpseq-metadata-service/defaults/main.yml
@@ -8,7 +8,7 @@ xml_schema_source_url: ftp://ftp.ebi.ac.uk/pub/databases/ena/doc/xsd/sra_1_5
 snpseq_metadata_src_path: "{{ sw_path }}/metadata/snpseq_metadata"
 
 snpseq_metadata_service_repo: https://github.com/Molmed/snpseq-metadata-service.git
-snpseq_metadata_service_version: 39752ef
+snpseq_metadata_service_version: 1.1.0
 
 snpseq_metadata_service_log_dir: "{{ static_ngi_log_path }}/metadata/snpseq_metadata_service/{{ deployment_environment }}"
 snpseq_metadata_service_src_path: "{{ sw_path }}/metadata/snpseq_metadata_service"


### PR DESCRIPTION
the new version of `nf-core` will include the version tag in the downloaded path. This accounts for that in the config.