### PR TITLE
specify full path to snpseq_metadata executable

### DIFF
--- a/roles/snpseq-metadata-service/templates/snpseq_metadata_service_app.config.j2
+++ b/roles/snpseq-metadata-service/templates/snpseq_metadata_service_app.config.j2
@@ -15,4 +15,4 @@ snpseq_data_url: http://localhost:4444
 
 # the path to the snpseq_metadata python package main script
 # will be deployed in the same env as the service
-snpseq_metadata_executable: snpseq_metadata
+snpseq_metadata_executable: {{ snpseq_metadata_env_path }}/bin/snpseq_metadata


### PR DESCRIPTION
- This adds the full path to the `snpseq_metadata` executable to the `snpseq-metadata-service` config
