### PR TITLE
update nextflow and nf-core to latest releases

### DIFF
--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -1,6 +1,6 @@
 java_home: /sw/comp/java/x86_64/OracleJDK_11.0.9
 nextflow_java: "{{ java_home }}"
-nextflow_version_tag: 23.10.0
+nextflow_version_tag: 24.04.1
 nextflow_download_url: https://github.com/nextflow-io/nextflow/releases/download/v{{ nextflow_version_tag }}/nextflow
 nextflow_local_env:
   NXF_HOME: "{{ nextflow_dest }}/workfiles"

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -1,6 +1,6 @@
 nf_core_env_name: nf-core-env
 nf_core_env: "{{ sw_path }}/anaconda/envs/{{ nf_core_env_name }}"
-nf_core_version: 2.13.1
+nf_core_version: 2.14.1
 nf_core_container_repo: docker://nfcore
 nf_core_vars:
   NFCORE_NO_VERSION_CHECK: 1


### PR DESCRIPTION
The python 3.12 update is not supported by the current nf-core version in bimonthly, therefore we decided to update both nf-core and nextflow and test if the deployment works then.