### PR TITLE
AV37137: Update to checkqc v4.0.3

### DIFF
--- a/roles/arteria-checkqc-ws/defaults/main.yml
+++ b/roles/arteria-checkqc-ws/defaults/main.yml
@@ -2,4 +2,4 @@ arteria_service_name: arteria-checkqc-ws
 arteria_checkqc_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 checkqc_repo: https://github.com/Molmed/checkQC.git
-checkqc_version: v4.0.2
+checkqc_version: v4.0.3


### PR DESCRIPTION
This update solves a bug where incorrect read numbers could be displayed in Q30 errors/warnings. 