### PR TITLE
Use nf-validation version in demux config

### DIFF
--- a/roles/arteria-sequencing-report-ws/tasks/install_config.yml
+++ b/roles/arteria-sequencing-report-ws/tasks/install_config.yml
@@ -45,9 +45,9 @@
 - name: deploying {{ arteria_service_name }} nextflow configs for pipelines
   template:
     src: "{{ item }}"
-    dest: "{{ arteria_service_nextflow_config_dir }}/{{ item | basename }}"
+    dest: "{{ arteria_service_nextflow_config_dir }}/{{ item | basename | splitext | first }}"
   with_fileglob:
-    - "../files/nextflow_configs/*.config"
+    - "../templates/nextflow_configs/*.config.j2"
 
 - name: Deploy arteria-delivery wrapper
   template:

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -10,6 +10,10 @@
 ----------------------------------------------------------------------------------------
 */
 
+plugins {
+    id 'nf-validation@{{ nf_validation_version }}'
+}
+
 process {
 
     withName: BCL2FASTQ {

--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -2,6 +2,7 @@ java_home: /sw/comp/java/x86_64/OracleJDK_11.0.9
 nextflow_java: "{{ java_home }}"
 nextflow_version_tag: 24.04.1
 nextflow_download_url: https://github.com/nextflow-io/nextflow/releases/download/v{{ nextflow_version_tag }}/nextflow
+nf_validation_version: 1.1.2
 nextflow_local_env:
   NXF_HOME: "{{ nextflow_dest }}/workfiles"
   NXF_OPTS: -Xms1g -Xmx3500m
@@ -20,7 +21,7 @@ nextflow_env:
   PATH: "{{ tools_path.PATH }}"
 nextflow_plugins:
   - name: nf-validation
-    version: 1.1.2
+    version: "{{ nf_validation_version }}"
   - name: nf-prov
     version: 1.2.1
   - name: nf-tower


### PR DESCRIPTION
By default, nf-core/demultiplex uses nf-validation 1.1.3 but miarka provision installs nf-validation 1.1.2. This PR makes sure nf-core/demultiplex uses the version that is actually installed on miarka.