### PR TITLE
Updates to monthly for Jul 2024 deployment

### DIFF
--- a/env_vars/site_sthlm_env_all.yml
+++ b/env_vars/site_sthlm_env_all.yml
@@ -24,6 +24,7 @@ multiqc_options:
   push_statusdb: True
   save_remote: True
   template: ngi
+  output_fn_name: multiqc_report.html
 
 multiqc_swedac_accredited: True
 multiqc_sshkey: /path/to/ssh_key

--- a/roles/multiqc/defaults/main.yml
+++ b/roles/multiqc/defaults/main.yml
@@ -4,4 +4,4 @@ multiqc_version: "v1.22.3"
 
 multiqc_ngi_repo: https://github.com/NationalGenomicsInfrastructure/MultiQC_NGI.git
 multiqc_ngi_dest: "{{ sw_path }}/multiqc_ngi"
-multiqc_ngi_version: "0.7.3"
+multiqc_ngi_version: "0.8.0"

--- a/roles/multiqc/templates/multiqc_config.yml.j2
+++ b/roles/multiqc/templates/multiqc_config.yml.j2
@@ -5,8 +5,11 @@ export_plots: true
 swedac_location: {{ site_full }}
 swedac_accredited: {{ multiqc_swedac_accredited }}
 
+#Restrict megaqc to upps for now
+{% if site == "upps" %}
 megaqc_url: {{ megaqc_url }}
 megaqc_access_token: {{ megaqc_access_token }}
+{% endif %}
 
 {% for key, value in multiqc_options | dictsort %}
 {{ key }}: {{ value }}

--- a/roles/ngi_reports/defaults/main.yml
+++ b/roles/ngi_reports/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ngi_reports_repo: https://github.com/NationalGenomicsInfrastructure/ngi_reports.git
 ngi_reports_dest: "{{ sw_path }}/ngi_reports"
-ngi_reports_version: 8bfd3bbab27cb6385edd6c128ef2e480d5af774c
+ngi_reports_version: 9946e96ff08d9ad4c51eea37ffe92964bc9f68be
 ngi_reports_log: "{{ ngi_log_path }}/ngi_reports.log"
 
 ngi_mdx_outline_repo: https://github.com/NationalGenomicsInfrastructure/mdx_outline.git


### PR DESCRIPTION
* Turn off megaqc for sthlm for now
* Add workaround for custom multiqc report name
* Update multiqc_ngi to 0.8.0 for compatibility with multiqc 1.22.3
* ngi_reports: Fix bug that the lane yield and Q30 values are inconsistent in the html and txt files