### PR TITLE
Install the package version specified in the requirements

### DIFF
--- a/roles/archive-upload-ws/tasks/1_install.yml
+++ b/roles/archive-upload-ws/tasks/1_install.yml
@@ -17,7 +17,6 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"
 
 - name: install archive-upload
   pip:
@@ -25,5 +24,3 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"
-

--- a/roles/archive-verify-ws/tasks/1_install.yml
+++ b/roles/archive-verify-ws/tasks/1_install.yml
@@ -17,4 +17,3 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"

--- a/roles/arteria-checkqc-ws/tasks/install.yml
+++ b/roles/arteria-checkqc-ws/tasks/install.yml
@@ -17,7 +17,6 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"
 
 - name: install CheckQC
   pip:
@@ -25,4 +24,3 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"

--- a/roles/arteria-checksum-ws/tasks/1_install.yml
+++ b/roles/arteria-checksum-ws/tasks/1_install.yml
@@ -17,7 +17,6 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"
 
 - name: install arteria-checksum
   pip:
@@ -25,5 +24,3 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"
-

--- a/roles/arteria-delivery-ws/tasks/install.yml
+++ b/roles/arteria-delivery-ws/tasks/install.yml
@@ -16,7 +16,6 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"
 
 - name: install arteria-delivery
   pip:
@@ -24,4 +23,3 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"

--- a/roles/arteria-sequencing-report-ws/tasks/install.yml
+++ b/roles/arteria-sequencing-report-ws/tasks/install.yml
@@ -17,7 +17,6 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"
 
 - name: install sequencing report service
   pip:
@@ -25,7 +24,6 @@
     chdir: "{{ arteria_service_src_path }}"
     executable: "{{ arteria_service_env_root }}/bin/pip"
     state: present
-    extra_args: "-U"
 
 - name: create temp folder
   tempfile:

--- a/roles/delivery/tasks/main.yml
+++ b/roles/delivery/tasks/main.yml
@@ -13,7 +13,6 @@
   pip:
     executable: "{{ delivery_env_path }}/bin/pip"
     requirements: "{{ delivery_dest }}/requirements.txt"
-    extra_args: "-U"
     state: present
 
 - name: install delivery into venv

--- a/roles/snpseq-metadata-service/tasks/install_package.yml
+++ b/roles/snpseq-metadata-service/tasks/install_package.yml
@@ -16,7 +16,7 @@
     chdir: "{{ snpseq_metadata_src_path }}"
     executable: "{{ snpseq_metadata_env_path }}/bin/pip"
     state: present
-    extra_args: "-U -e"
+    extra_args: "-e"
 
 - name: download XML schema
   command: "{{ snpseq_metadata_env_path }}/bin/generate_python_models.sh {{ snpseq_metadata_env_path }}/bin/xsdata {{ xml_schema_source_url }}"

--- a/roles/snpseq-metadata-service/tasks/install_service.yml
+++ b/roles/snpseq-metadata-service/tasks/install_service.yml
@@ -16,4 +16,3 @@
     chdir: "{{ snpseq_metadata_service_src_path }}"
     executable: "{{ snpseq_metadata_env_path }}/bin/pip"
     state: present
-    extra_args: "-U"


### PR DESCRIPTION
Numpy 2.0.0 was released a few weeks ago and this broke CheckQC. This happened because when we install our services' requirements, we always install the latest version. This is not the behavior we want, we want the version specified in the requirements to be installed instead. This PR fixes that issue.

For the record, a similar issue was encountered several months ago in our internal playbooks: https://gitlab.snpseq.medsci.uu.se/ops/system-management/-/merge_requests/729