### PR TITLE
Add temporary checkqc hotfix

### DIFF
--- a/roles/arteria-checkqc-ws/tasks/install_config.yml
+++ b/roles/arteria-checkqc-ws/tasks/install_config.yml
@@ -21,9 +21,9 @@
     section: program:{{ arteria_service_name }}-{{ deployment_environment }}
     option: command
     value: >
-      {{ arteria_service_env_root }}/bin/checkqc-ws
-      --config {{ arteria_service_config_root }}/app.config
-      --log_config {{ arteria_service_config_root }}/logger.config
+      /vulpes/ngi/production/v24.03/sw/anaconda/envs/arteria-checkqc-ws/bin/checkqc-ws
+      --config /vulpes/ngi/production/v24.03/conf/arteria/arteria-checkqc-ws/app.config
+      --log_config /vulpes/ngi/production/v24.03/conf/arteria/arteria-checkqc-ws/logger.config
       --port={{ checkqc_service_port }}
       {{ static_runfolder_path }}
     backup: no


### PR DESCRIPTION
Due to an issue in later versions of CheckQC, we have hotfixed supervisord to use an older deployment of CheckQC. Since it is unclear if the CheckQC bug will be fixed until the next miarka-provision release, given vacations and so on, this PR implements the hotfix so that it is re-applied without manual intervention. This commit should be reverted when CheckQC has been fixed. 