### PR TITLE
Fix Interop path for demultiplex pipeline

### DIFF
--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -40,7 +40,7 @@ process {
             ],
             [
                 // Gather and write InterOp files
-                path: { "${params.outdir}/InterOp" },
+                path: { "${params.outdir}" },
                 mode: "link",
                 pattern: "**.bin",
             ],


### PR DESCRIPTION
The former path led to new interop files being placed in a nested folder `InterOp/InterOp`. This PR addresses this issue.