### PR TITLE
Dataops-788 Give bcl2fastq more resources

### DIFF
--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -17,6 +17,9 @@ plugins {
 process {
 
     withName: BCL2FASTQ {
+        time = '32h'
+        cpus = 24
+        memory = '147G'
         ext.args = {[
             params.ext_args ? "${params.ext_args}" : "",
         ].join(" ").trim()}


### PR DESCRIPTION
We noticed that a runfolder failed the bcl2fastq process on the first try and was re-launched with these parameters successfully. This is probably more than we need, but we will profile the demultiplex pipeline later to optimize parameters: https://snpseq.atlassian.net/browse/DATAOPS-787