### PR TITLE
DATAOPS-779: checkqc v4.0.5

### DIFF
--- a/roles/arteria-checkqc-ws/defaults/main.yml
+++ b/roles/arteria-checkqc-ws/defaults/main.yml
@@ -2,4 +2,4 @@ arteria_service_name: arteria-checkqc-ws
 arteria_checkqc_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 checkqc_repo: https://github.com/Molmed/checkQC.git
-checkqc_version: v4.0.4
+checkqc_version: v4.0.5

--- a/roles/arteria-checkqc-ws/tasks/install_config.yml
+++ b/roles/arteria-checkqc-ws/tasks/install_config.yml
@@ -21,9 +21,9 @@
     section: program:{{ arteria_service_name }}-{{ deployment_environment }}
     option: command
     value: >
-      /vulpes/ngi/production/v24.03/sw/anaconda/envs/arteria-checkqc-ws/bin/checkqc-ws
-      --config /vulpes/ngi/production/v24.03/conf/arteria/arteria-checkqc-ws/app.config
-      --log_config /vulpes/ngi/production/v24.03/conf/arteria/arteria-checkqc-ws/logger.config
+      {{ arteria_service_env_root }}/bin/checkqc-ws
+      --config {{ arteria_service_config_root }}/app.config
+      --log_config {{ arteria_service_config_root }}/logger.config
       --port={{ checkqc_service_port }}
       {{ static_runfolder_path }}
     backup: no


### PR DESCRIPTION
This PR updates CheckQC to v4.0.5 and reverts the bug workaround.

This version has been verified locally (verification protocol can be found in confluence). 