### PR TITLE
Dataops 818 snpseq packs v8.0.0 improvements

### DIFF
--- a/roles/arteria-sequencing-report-ws/files/hiseq.rsync
+++ b/roles/arteria-sequencing-report-ws/files/hiseq.rsync
@@ -37,6 +37,9 @@
 # Exclude all .sentinel files
 - .sentinel
 
+# Exclude all .nextflow directory
+- .nextflow
+
 # Include full tree of some subdirs
 # This works if rsync is called with src dest, but not src/ dest
 + /*/Sisyphus/***

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -14,10 +14,6 @@ plugins {
     id 'nf-validation@{{ nf_validation_version }}'
 }
 
-params {
-   skip_tools = 'md5sum'
-}
-
 process {
 
     withName: BCL2FASTQ {

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -51,7 +51,7 @@ process {
     }
 
     withName: MD5SUM {
-        publishDir = []
+        publishDir enabled:false
     }
 }
 

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -14,6 +14,10 @@ plugins {
     id 'nf-validation@{{ nf_validation_version }}'
 }
 
+params {
+   skip_tools = 'MD5SUM'
+}
+
 process {
 
     withName: BCL2FASTQ {
@@ -50,8 +54,4 @@ process {
         ]
     }
 
-    withName: MD5SUM {
-        publishDir enabled:false
-    }
 }
-

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -15,7 +15,7 @@ plugins {
 }
 
 params {
-   skip_tools = 'MD5SUM'
+   skip_tools = 'md5sum'
 }
 
 process {

--- a/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
+++ b/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
@@ -20,7 +20,7 @@ pipeline_parameters:
   outdir: "{runfolder_path}"
   project: {{uppmax_project}}
   demultiplexer: "bcl2fastq"
-  skip_tools: "fastp,falco,multiqc"
+  skip_tools: "fastp,falco,multiqc,md5sum"
 input_samplesheet_content: |
   id,samplesheet,lane,flowcell
   {runfolder_name},{runfolder_path}/SampleSheet.csv,,{runfolder_path}


### PR DESCRIPTION
This code has snpseq_packs v8.0.4 improvements for the ngi_uu_workflow with the following changes;

- Excludes the .nextflow directory while updating the checksums after demultiplexing.

- Skipping the md5sums module in the demultiplex pipeline .

Ticket: https://snpseq.atlassian.net/browse/DATAOPS-818

Validation protocol: https://snpseq.atlassian.net/wiki/spaces/AR/pages/3717988353/WIP+Verification+of+snpseq_packs+v8.0.7