### PR TITLE
Update nf-core/demultiplex to 1.5.4

### DIFF
--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -50,7 +50,7 @@ sarek_dest: "{{ sw_path }}/sarek/{{ sarek_tag | replace('.', '_') }}"
 rnaseq_tag: "3.8.1"
 rnaseq_dest: "{{ sw_path }}/rnaseq/{{ rnaseq_tag | replace('.', '_') }}"
 
-demultiplex_tag: "1.4.1"
+demultiplex_tag: "1.5.4"
 
 # File with tools/software version in the deployed env
 deployed_tool_versions: "{{ ngi_resources }}/deployed_tools.{{ site }}.version"

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -11,7 +11,7 @@
 */
 
 plugins {
-    id 'nf-schema@{{ nf_schema_version }}
+    id 'nf-schema@{{ nf_schema_version }}'
 }
 
 process {

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -11,7 +11,7 @@
 */
 
 plugins {
-    id 'nf-validation@{{ nf_validation_version }}'
+    id 'nf-schema@{{ nf_schema_version }}
 }
 
 process {
@@ -26,19 +26,21 @@ process {
         publishDir = [
             [
                 path: { "${params.outdir}/Unaligned/" },
-                pattern: "**_S[1-9]*_*.fastq.gz",
+                pattern: "output/**_S[1-9]*_*.fastq.gz",
                 mode: "link",
+                saveAs: { filename -> filename.minus("output/") }
             ],
             [
                 path: { "${params.outdir}/Unaligned/" },
-                pattern: "Undetermined_S0_*.fastq.gz",
+                pattern: "output/**Undetermined_S0_*.fastq.gz",
                 mode: "link",
+                saveAs: { filename -> filename.minus("output/") }
             ],
             [
                 // Gather and write Reports and Stats
                 path: { "${params.outdir}/Unaligned/" },
                 mode: "link",
-                pattern: "Stats",
+                pattern: "output/{Stats,Reports}",
                 saveAs: {filename -> filename.split("/")[-1] }
             ],
             [
@@ -49,5 +51,4 @@ process {
             ],
         ]
     }
-
 }

--- a/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
+++ b/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
@@ -20,7 +20,7 @@ pipeline_parameters:
   outdir: "{runfolder_path}"
   project: {{uppmax_project}}
   demultiplexer: "bcl2fastq"
-  skip_tools: "fastp,falco,multiqc,md5sum"
+  skip_tools: "samshee,checkqc,fastp,falco,md5sum,kraken,multiqc"
 input_samplesheet_content: |
   id,samplesheet,lane,flowcell
   {runfolder_name},{runfolder_path}/SampleSheet.csv,,{runfolder_path}

--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -2,7 +2,7 @@ java_home: /sw/comp/java/x86_64/OracleJDK_11.0.9
 nextflow_java: "{{ java_home }}"
 nextflow_version_tag: 24.04.1
 nextflow_download_url: https://github.com/nextflow-io/nextflow/releases/download/v{{ nextflow_version_tag }}/nextflow
-nf_validation_version: 1.1.2
+nf_schema_version: 2.1.1
 nextflow_local_env:
   NXF_HOME: "{{ nextflow_dest }}/workfiles"
   NXF_OPTS: -Xms1g -Xmx3500m
@@ -21,8 +21,10 @@ nextflow_env:
   PATH: "{{ tools_path.PATH }}"
 nextflow_plugins:
   - name: nf-validation
-    version: "{{ nf_validation_version }}"
+    version: 1.1.2
   - name: nf-prov
     version: 1.2.1
   - name: nf-tower
     version: 1.6.3
+  - name: nf-schema # Will replace nf-validation once we update all our pipelines
+    version: "{{ nf_schema_version }}"


### PR DESCRIPTION
When running bcl2fastq, nf-core/demultiplex uses the input directory as work directory, this means that if fastq files are already there from a previous run, they will be picked up by nextflow and written to the pipeline output directory.

This might trip re-runs (see https://github.com/nf-core/demultiplex/issues/106) and downstream analysis pipelines (such as seqreports).

This was fixed in https://github.com/nf-core/modules/pull/6112 and included in nf-core/demultiplex v1.5.0 by restricting bcl2fastq's output to a special `output` directory, which makes it easier to only select these files when using the `publishDir` directive.

This PR updates nf-core/demultiplex to the latest version and refines the `publishDir` pattern.