### PR TITLE
DATAOPS-962: Increase timeout limits for arteria-delivery

### DIFF
--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -13,6 +13,9 @@ services:
   - name: arteria_delivery
     host: localhost
     port: {{ arteria_delivery_port }}
+    connect_timeout: 600000
+    read_timeout: 600000
+    write_timeout: 600000
     routes:
     - paths:
       - /arteria_delivery


### PR DESCRIPTION
This PR solves an issue where Kong would terminate with `Upstream server is timing out". This was caused by the dds-cli being slow and dds commands taking longer than 60s. Timeouts for the arteria-delivery service has now been increased to 600s (the config specifies limits in milliseconds) to avoid this issue. 

This change was first tested in staging making sure that it did not break anything, it was then applied as an hotifx in the current production environment. There is could be seen that a command could run for ~ 62 s without failing. 