### PR TITLE
Revert cleanup = False for upps

### DIFF
--- a/roles/nextflow/templates/nextflow_miarka_site.config.j2
+++ b/roles/nextflow/templates/nextflow_miarka_site.config.j2
@@ -1,9 +1,5 @@
 
-{% if site == "upps" %}
-cleanup = false
-{% else %}
 cleanup = true
-{% endif %}
 
 params {
 


### PR DESCRIPTION
A while back we disabled workdir cleanups for Uppsala. The reason for this was to be able to look at process details for successful pipeline executions. This is sometimes needed when troubleshooting tasks that are allowed to fail or to document commands used. This is mainly needed for analysis pipelines. 

This config change does however affect pipeline run in our pipelines for runfolder processing as well and the workdirs do accumulate a lot of data when re-running the demultiplex pipeline.

This PR sets cleanup to true for Uppsala again and will be set to false in a analysis specific config instead. 