### PR TITLE
Download nf-core/rnaseq from forked repository

### DIFF
--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -47,7 +47,7 @@ ngi_resources: "{{ root_path }}/resources/"
 sarek_tag: "3.4.2"
 sarek_dest: "{{ sw_path }}/sarek/{{ sarek_tag | replace('.', '_') }}"
 
-rnaseq_tag: "3.12.0_ngi_v1-rc1"
+rnaseq_tag: "v3.12.0_ngi_v1-rc1"
 rnaseq_dest: "{{ sw_path }}/rnaseq/{{ rnaseq_tag | replace('.', '_') }}"
 
 demultiplex_tag: "1.5.4"

--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -47,7 +47,7 @@ ngi_resources: "{{ root_path }}/resources/"
 sarek_tag: "3.4.2"
 sarek_dest: "{{ sw_path }}/sarek/{{ sarek_tag | replace('.', '_') }}"
 
-rnaseq_tag: "3.12.0"
+rnaseq_tag: "3.12.0_ngi_v1-rc1"
 rnaseq_dest: "{{ sw_path }}/rnaseq/{{ rnaseq_tag | replace('.', '_') }}"
 
 demultiplex_tag: "1.5.4"

--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -1,6 +1,6 @@
 java_home: /sw/comp/java/x86_64/OracleJDK_11.0.9
 nextflow_java: "{{ java_home }}"
-nextflow_version_tag: 24.04.1
+nextflow_version_tag: 24.04.4
 nextflow_download_url: https://github.com/nextflow-io/nextflow/releases/download/v{{ nextflow_version_tag }}/nextflow
 nf_schema_version: 2.1.1
 nextflow_local_env:

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -16,7 +16,7 @@ nf_core_vars:
   PATH: "{{ nf_core_env }}/bin:{{ tools_path.PATH }}"
 biocontainers_dirname: biocontainers
 pipelines:
-  - name: rnaseq
+  - name: NationalGenomicsInfrastructure/nfcore_rnaseq
     release: "{{ rnaseq_tag }}"
     container_dir: "{{ biocontainers_dirname }}"
   - name: sarek

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -16,9 +16,10 @@ nf_core_vars:
   PATH: "{{ nf_core_env }}/bin:{{ tools_path.PATH }}"
 biocontainers_dirname: biocontainers
 pipelines:
-  - name: NationalGenomicsInfrastructure/nfcore_rnaseq
+  - name: rnaseq
     release: "{{ rnaseq_tag }}"
     container_dir: "{{ biocontainers_dirname }}"
+    repository: NationalGenomicsInfrastructure/nfcore_rnaseq
   - name: sarek
     release: "{{ sarek_tag }}"
     container_dir: "{{ biocontainers_dirname }}"

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -45,7 +45,7 @@ pipelines:
           accession: NC_001416.1
           sha1: 2b03cbf38a8e6816914b172f048a2fe896317df7
   - name: ampliseq
-    release: 2.5.0
+    release: 2.12.0
     extra_parameters:
       silva_base_url: https://www.arb-silva.de/fileadmin/silva_databases/qiime
       silva_zip: Silva_132_release.zip

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -1,6 +1,6 @@
 nf_core_env_name: nf-core-env
 nf_core_env: "{{ sw_path }}/anaconda/envs/{{ nf_core_env_name }}"
-nf_core_version: 2.14.1
+nf_core_version: 3.0.2
 nf_core_container_repo: docker://nfcore
 nf_core_vars:
   NFCORE_NO_VERSION_CHECK: 1

--- a/roles/nf-core/tasks/main.yml
+++ b/roles/nf-core/tasks/main.yml
@@ -17,6 +17,7 @@
     pipeline_genomes: "{{ item.pipeline_genomes | default([]) }}"
     extra_parameters: "{{ item.extra_parameters | default({}) }}"
     container_dir: "{{ ngi_containers }}/{{ item.container_dir | default(item.name) }}"
+    repository: "{{ item.repository | default(item.name) }}"
   with_items: "{{ pipelines }}"
   tags: pipelines
 

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -14,23 +14,24 @@
   loop_control:
     loop_var: cachedir
 
-- name: nf-core download {{ pipeline }} v{{ release }}
+- name: nf-core download {{ pipeline }} {{ release }}
   command: >
     nf-core -v
-    pipeline download {{ repository }}
-    -d
+    pipelines download {{ repository }}
+    --download-configuration yes
     --compress none
     --outdir {{ sw_path }}/{{ pipeline }}
     --revision {{ release }}
     --container-system singularity
     --container-cache-utilisation amend
+    --parallel-downloads 4
   environment: "{{ nf_core_vars }}"
   ignore_errors: true
   args:
     chdir: "{{ sw_path }}"
     creates: "{{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') }}"
 
-- name: pull pipeline-specific images for {{ pipeline }} v{{ release }}
+- name: pull pipeline-specific images for {{ pipeline }} {{ release }}
   command: "singularity pull --name nfcore-{{ container.0 }}.{{ container.1 }}.img {{ nf_core_container_repo }}/{{ container.0 | replace('-', ':', 1) }}.{{ container.1 }}"
   environment: "{{ nf_core_vars }}"
   args:
@@ -43,12 +44,12 @@
   loop_control:
     loop_var: container
 
-- name: create nf-core {{ pipeline }} v{{ release }} config
+- name: create nf-core {{ pipeline }} {{ release }} config
   template:
     src: "site.config.j2"
     dest: "{{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config"
 
-- name: set alias for pipeline {{ pipeline }} v{{ release }}
+- name: set alias for pipeline {{ pipeline }} {{ release }}
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/{{ bash_env_script }}"
     line: >

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -17,7 +17,7 @@
 - name: nf-core download {{ pipeline }} v{{ release }}
   command: >
     nf-core -v
-    download {{ pipeline }}
+    pipeline download {{ repository }}
     -d
     --compress none
     --outdir {{ sw_path }}/{{ pipeline }}


### PR DESCRIPTION
This PR introduces the following changes:
- download nf-core/rnaseq from forked repository https://github.com/NationalGenomicsInfrastructure/nfcore_rnaseq
- update nf-core/tools to v3.0.2 (3.1.1 is not available on bioconda yet), and nextflow to 24.0.4 (required by nf-core/tools)
- Update nf-core/ampliseq to 2.12.0 (downloading ampliseq prior to version 2.9.0 fails)