### PR TITLE
Update nextflow to 24.04.2 since required by nf-core/demultiplex

### DIFF
--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -1,6 +1,6 @@
 java_home: /sw/comp/java/x86_64/OracleJDK_11.0.9
 nextflow_java: "{{ java_home }}"
-nextflow_version_tag: 24.04.1
+nextflow_version_tag: 24.04.2
 nextflow_download_url: https://github.com/nextflow-io/nextflow/releases/download/v{{ nextflow_version_tag }}/nextflow
 nf_schema_version: 2.1.1
 nextflow_local_env:


### PR DESCRIPTION
This patch update is needed by nf-core/demultiplex v1.5.4. This change will be validated in a staging environment. 