### PR TITLE
Fix uppmax profile for demultiplex

### DIFF
--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -14,6 +14,12 @@ plugins {
     id 'nf-schema@{{ nf_schema_version }}'
 }
 
+profiles {
+    uppmax {
+        includeConfig "${projectDir}/../configs/conf/uppmax.config"
+    }
+}
+
 process {
 
     withName: BCL2FASTQ {


### PR DESCRIPTION
There is a bug in the nf-core template that prevents institutional configs to be loaded when running in offline mode.

This commit temporarily fixes that until this is fixed in the template.

OBS: this bug in the template might affect other pipelines as we update them.