### PR TITLE
Update sequencing-report-service to v1.5.2

### DIFF
--- a/roles/arteria-sequencing-report-ws/defaults/main.yml
+++ b/roles/arteria-sequencing-report-ws/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 seqreport_service_repo: https://github.com/arteria-project/sequencing-report-service.git
-seqreport_service_version: v1.5.1-rc2
+seqreport_service_version: v1.5.2
 
 arteria_service_name: arteria-sequencing-report-ws
 arteria_sequencing_report_wrapper: "{{ arteria_service_config_root }}/arteria_sequencing_report_wrapper.sh"


### PR DESCRIPTION
This PR updates the sequencing-report-service to a version where the seqreports pipeline has been updated to accommodate a small change in nf-core/demultiplex. Read more here: https://github.com/Molmed/seqreports/pull/65

The change in seqreports was tested as a hotfix in staging version `250127.3097bf2`