### PR TITLE
replace - with _ in pipeline alias

### DIFF
--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -52,7 +52,7 @@
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/{{ bash_env_script }}"
     line: >
-          alias {{ pipeline }}='nextflow run {{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') }}/
+          alias {{ pipeline }}='nextflow run {{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') | replace('-', '_')}}/
           -profile uppmax \
           -c {{ ngi_pipeline_conf }}/nextflow_miarka_{{ site }}.config \
           -c {{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config'


### PR DESCRIPTION
In some cases a - is included in the pipeline version. This is converted to _ in the path but not in the alias. This should fix the issue.