### PR TITLE
Follow nf-core naming for pipeline releases

### DIFF
--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -45,10 +45,10 @@ ngi_pipeline_conf: "{{ root_path }}/conf/"
 ngi_resources: "{{ root_path }}/resources/"
 
 sarek_tag: "3.4.2"
-sarek_dest: "{{ sw_path }}/sarek/{{ sarek_tag | replace('.', '_') }}"
+sarek_dest: "{{ sw_path }}/sarek/{{ sarek_tag | regex_replace('[^0-9a-zA-Z_]+', '_') }}"
 
 rnaseq_tag: "v3.12.0_ngi_v1-rc1"
-rnaseq_dest: "{{ sw_path }}/rnaseq/{{ rnaseq_tag | replace('.', '_') }}"
+rnaseq_dest: "{{ sw_path }}/rnaseq/{{ rnaseq_tag | regex_replace('[^0-9a-zA-Z_]+', '_')  }}"
 
 demultiplex_tag: "1.5.4"
 

--- a/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
+++ b/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
@@ -1,6 +1,6 @@
 ---
 
-main_workflow_path: "{{ sw_path }}/demultiplex/{{ demultiplex_tag | replace('.', '_') }}/main.nf"
+main_workflow_path: "{{ sw_path }}/demultiplex/{{ demultiplex_tag | regex_replace('[^0-9a-zA-Z_]+', '_') }}/main.nf"
 # Note that in the following sections it is possible to do variable subsitution
 # on the following variables:
 # - {runfolder_name}

--- a/roles/nf-core/tasks/main.yml
+++ b/roles/nf-core/tasks/main.yml
@@ -18,6 +18,9 @@
     extra_parameters: "{{ item.extra_parameters | default({}) }}"
     container_dir: "{{ ngi_containers }}/{{ item.container_dir | default(item.name) }}"
     repository: "{{ item.repository | default(item.name) }}"
+    # `nf-core pipelines download` does this replacement to make the folder names
+    # 'filesystem-safe', so we need to do it too.
+    release_path: "{{ sw_path }}/{{ pipeline }}/{{ item.release | regex_replace('[^0-9a-zA-Z_]+', '_') }}"
   with_items: "{{ pipelines }}"
   tags: pipelines
 

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -53,7 +53,7 @@
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/{{ bash_env_script }}"
     line: >
-          alias {{ pipeline }}='nextflow run {{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') }}/
+          alias {{ pipeline }}='nextflow run {{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') | replace('-', '_')}}/
           -profile uppmax \
           -c {{ ngi_pipeline_conf }}/nextflow_miarka_{{ site }}.config \
           -c {{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config'

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -29,7 +29,7 @@
   ignore_errors: true
   args:
     chdir: "{{ sw_path }}"
-    creates: "{{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') }}"
+    creates: "{{ release_path }}"
 
 - name: pull pipeline-specific images for {{ pipeline }} {{ release }}
   command: "singularity pull --name nfcore-{{ container.0 }}.{{ container.1 }}.img {{ nf_core_container_repo }}/{{ container.0 | replace('-', ':', 1) }}.{{ container.1 }}"
@@ -53,7 +53,7 @@
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/{{ bash_env_script }}"
     line: >
-          alias {{ pipeline }}='nextflow run {{ sw_path }}/{{ pipeline }}/{{ release | replace('.', '_') | replace('-', '_')}}/
+          alias {{ pipeline }}='nextflow run {{ release_path }}/
           -profile uppmax \
           -c {{ ngi_pipeline_conf }}/nextflow_miarka_{{ site }}.config \
           -c {{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config'


### PR DESCRIPTION
I fell down a bit of a rabbit hole with regards to #318. Jun had discovered that the `rnaseq` alias we create in the `sourceme` files does not match the actual path of the rnaseq release we deploy. The alias has a hyphen where an underscore should be. This specific issue is fixed in #318, but I was confused why this was happening in the first place, so I investigated.

Long story short, `nf-core pipelines download` [makes the revision name 'filesystem-safe'](https://github.com/nf-core/tools/blob/52e810986e382972ffad0aab28e94f828ffd509b/nf_core/pipelines/download.py#L639) by putting a `_` in place of anything that isn't a letter (a-z, lower or upper case) or a digit.

So far, we only had release names that contained dots, which meant that for our aliases it was enough to use a simple Jinja2 `replace` filter. But I think for future-proofing it would be best, if we just did the same thing that `nf-core` does