### PR TITLE
Fix pipeline deployment

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -81,7 +81,9 @@ nf_core_delivery_readmes:
   methylseq:
     - DELIVERY.README.METHYLSEQ.md
 
-awscli_version: 2.15.57
+awscli_env_name: awscli-env
+awscli_env: "{{ sw_path }}/anaconda/envs/{{ awscli_env_name }}"
+awscli_version: 2.24.27
 aws_igenomes_repo: https://github.com/ewels/AWS-iGenomes.git
 aws_igenomes_commit: dda1d928fdb0d018aabbf91ac6ce8e153b699991
 aws_igenomes_dest: "{{ sw_path }}/AWS-iGenomes"

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -1,6 +1,6 @@
 nf_core_env_name: nf-core-env
 nf_core_env: "{{ sw_path }}/anaconda/envs/{{ nf_core_env_name }}"
-nf_core_version: 3.0.2
+nf_core_version: 3.2.0
 nf_core_container_repo: docker://nfcore
 nf_core_vars:
   NFCORE_NO_VERSION_CHECK: 1

--- a/roles/nf-core/tasks/igenomes.yml
+++ b/roles/nf-core/tasks/igenomes.yml
@@ -1,3 +1,19 @@
+---
+- name: "Check if {{ awscli_env_name }} virtual env exists"
+  shell: "conda env list"
+  register: "conda_envs"
+
+- name: >
+    Setup {{ awscli_env_name }} virtual env
+    with python {{ python3_version }} and awscli v{{ awscli_version }}
+  command: >
+    conda create -n {{ nf_core_env_name }}
+    -c conda-forge
+    -c bioconda
+    python={{ python3_version }}
+    awscli={{ awscli_version }}
+  when: not awscli_env_name in conda_envs.stdout|split
+
 
 - name: get AWS-igenomes from git
   git:
@@ -19,7 +35,7 @@
     {{ ['-t', item.type] | join if item.type else '' }}
     -q"
   environment:
-    PATH: "{{ nf_core_env }}/bin"
+    PATH: "{{ awscli_env }}/bin"
   args:
     chdir: "{{ igenomes_dir }}"
     creates: "{{ igenomes_dir }}/references/{{ item.genome }}/{{ item.source }}/{{ item.build }}"

--- a/roles/nf-core/tasks/main.yml
+++ b/roles/nf-core/tasks/main.yml
@@ -1,11 +1,19 @@
 ---
 - name: "Check if {{ nf_core_env_name }} virtual env exists"
   shell: "conda env list"
-  register: "nfcore_envs"
+  register: "conda_envs"
 
-- name: Setup {{ nf_core_env_name }} virtual env with python3 and nf-core v{{ nf_core_version }}
-  command: "conda create -n {{ nf_core_env_name }} -c conda-forge -c bioconda python={{ python3_version }} nf-core={{ nf_core_version }} nextflow={{ nextflow_version_tag }} awscli={{ awscli_version }}"
-  when: not nf_core_env_name in nfcore_envs.stdout|split
+- name: >
+    Setup {{ nf_core_env_name }} virtual env
+    with python {{ python3_version }} and nf-core v{{ nf_core_version }}
+  command: >
+    conda create -n {{ nf_core_env_name }}
+    -c conda-forge
+    -c bioconda
+    python={{ python3_version }}
+    nf-core={{ nf_core_version }}
+    nextflow={{ nextflow_version_tag }}
+  when: not nf_core_env_name in conda_envs.stdout|split
 
 # Setup pipelines
 - name: setup nf-core pipelines

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -49,7 +49,7 @@
     src: "site.config.j2"
     dest: "{{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config"
 
-# TODO remove --igenome_base once nf-core/methylseq uses a template version
+# TODO remove --igenome_base once all our pipelines uses a template version
 # that addresses https://github.com/nf-core/tools/issues/3430
 - name: set alias for pipeline {{ pipeline }} {{ release }}
   lineinfile:
@@ -59,7 +59,7 @@
           -profile uppmax
           -c {{ ngi_pipeline_conf }}/nextflow_miarka_{{ site }}.config
           -c {{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config'
-          {{ '--igenome_base "{{ igenomes_dir }}"' if pipeline == "methylseq" else '' }}
+          --igenome_base {{ igenomes_dir }}
     backup: no
 
 - name: check if pipeline-specific include exists

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -59,7 +59,7 @@
           -profile uppmax
           -c {{ ngi_pipeline_conf }}/nextflow_miarka_{{ site }}.config
           -c {{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config'
-          --igenome_base {{ igenomes_dir }}
+          --igenomes_base {{ igenomes_dir }}
     backup: no
 
 - name: check if pipeline-specific include exists

--- a/roles/nf-core/templates/site.config.j2
+++ b/roles/nf-core/templates/site.config.j2
@@ -9,7 +9,6 @@ singularity.cacheDir = '{{ nf_core_vars.NXF_SINGULARITY_CACHEDIR }}'
 
 /* This is a patch to address this issue https://github.com/nf-core/tools/issues/3430
    It won't be necessary after the nf-core template is updated. */
-igenomes_base = {{ igenomes_dir }}
 profiles {
     uppmax {
         includeConfig "${projectDir}/../configs/conf/uppmax.config"


### PR DESCRIPTION
This PR addresses the following issues:
- Specify igenome path through a cli argument:
  - this is mainly due to nf-core/tools#3430 and will be an issue for all pipelines that use a template version between 3.0.0 and 3.2.0
- Update nf-core to v3.2.0: during validation:
  - it was noticed that some singularity images were missing from the deployment. This was due to nf-core/tools#3285 and should be fixed in nf-core 3.1 and above
- Create a new separate environment for `awscli`:
  - this package requires `prompt_toolkit<3.0.39` but the bioconda version of nf-core/tools requires `prompt_toolkit >=3.0.48`