### PR TITLE
Hardcode path to igenomes

### DIFF
--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -59,7 +59,7 @@
           -profile uppmax
           -c {{ ngi_pipeline_conf }}/nextflow_miarka_{{ site }}.config
           -c {{ ngi_pipeline_conf }}/{{ pipeline }}_{{ site }}.config
-          --igenomes_base {{ igenomes_dir }}'
+          --igenomes_base /sw/data/igenomes/'
     backup: no
 
 - name: check if pipeline-specific include exists


### PR DESCRIPTION
`igenomes_dir` points to the igenomes directory on vulpes, but the variable in the uppmax config points to `/sw/data/igenomes`.

We want to use the value from the Uppmax config here. This is hardcoded since this is a temporary fix until the issue with the nf-core template is fixed.