### PR TITLE
Bump checkQC to v4.0.6

### DIFF
--- a/roles/arteria-checkqc-ws/defaults/main.yml
+++ b/roles/arteria-checkqc-ws/defaults/main.yml
@@ -2,4 +2,4 @@ arteria_service_name: arteria-checkqc-ws
 arteria_checkqc_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 checkqc_repo: https://github.com/Molmed/checkQC.git
-checkqc_version: v4.0.5
+checkqc_version: v4.0.6


### PR DESCRIPTION
Bumb checkQC version after validation of the task that does the following:

- Updates the terminology in CheckQC so that we refer to all reads and indexes as their “read number”, and then specify if it is an index or not. This would correspond to the way InterOp stats are displayed in MultiQC. Example: A Paried-End run with dual index would have: Read 1, Read 2 (I), Read 3 (I) and Read 4.