### PR TITLE
Revert "Bump checkQC to v4.0.6"

### DIFF
--- a/roles/arteria-checkqc-ws/defaults/main.yml
+++ b/roles/arteria-checkqc-ws/defaults/main.yml
@@ -2,4 +2,4 @@ arteria_service_name: arteria-checkqc-ws
 arteria_checkqc_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 checkqc_repo: https://github.com/Molmed/checkQC.git
-checkqc_version: v4.0.6
+checkqc_version: v4.0.5


### PR DESCRIPTION
Reverts NationalGenomicsInfrastructure/miarka-provision#330

A bug was discovered in this version: https://github.com/Molmed/checkQC/issues/130
