### PR TITLE
Rsync with `--no-times`

### DIFF
--- a/sync.yml
+++ b/sync.yml
@@ -77,7 +77,7 @@
         ssh_connection_multiplexing: yes
         rsync_timeout: 60
         rsync_opts:
-          - --omit-dir-times
+          - --no-times
           - --relative
           - --progress
           - --verbose


### PR DESCRIPTION
Since we re-downloaded all containers, the container files on miarka3 now have different modification times than the ones that have previously been synced to the production system. This causes `rsync` to want to change the modification times on the production system. But because the individual files are owned by whatever user first synced them to production, this fails with `permission denied`.

This PR changes the sync playbook such that the modification times are not synced.