### PR TITLE
Bump sequencing-report-service to v1.5.3-rc1

### DIFF
--- a/roles/arteria-sequencing-report-ws/defaults/main.yml
+++ b/roles/arteria-sequencing-report-ws/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 seqreport_service_repo: https://github.com/arteria-project/sequencing-report-service.git
-seqreport_service_version: v1.5.2
+seqreport_service_version: v1.5.3-rc1
 
 arteria_service_name: arteria-sequencing-report-ws
 arteria_sequencing_report_wrapper: "{{ arteria_service_config_root }}/arteria_sequencing_report_wrapper.sh"


### PR DESCRIPTION
Updates the sequencing-report-service to v1.5.3-rc1. 

This version should be verified in the next staging env (current one is 250429.522b612). If a new staging deployment is made before the next production release, this change can be included, otherwise it should wait until after the next production deployment (currently the latest one is v25.03).