### PR TITLE
Increase timeout for bcl2fastq process

### DIFF
--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -25,7 +25,7 @@ profiles {
 process {
 
     withName: BCL2FASTQ {
-        time = '48h'
+        time = '72h'
         cpus = 24
         memory = '147G'
         ext.args = {[


### PR DESCRIPTION
Increase timeout for bcl2fastq process. See https://snpseq.atlassian.net/browse/DATAOPS-1086 for details. 

Has been applied as hotfix previously so no verification needed.