### PR TITLE
Downgrade container for BISMARK_ALIGN

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -34,6 +34,9 @@ pipelines:
       - CanFam3.1
       - WBcel235
   - name: methylseq
+    # TODO Evaluate if workaround implemented in
+    # https://github.com/NationalGenomicsInfrastructure/miarka-provision/pull/340
+    # can be removed when upgrading the methylseq pipeline
     release: 3.0.0
     container_dir: "{{ biocontainers_dirname }}"
     extra_parameters:

--- a/roles/nf-core/templates/site.config.j2
+++ b/roles/nf-core/templates/site.config.j2
@@ -31,7 +31,7 @@ process {
   }
 
 
-/* Temporary downgrade of bismark to work around the issue described here:
+/* TODO Temporary downgrade of bismark to work around the issue described here:
    https://github.com/FelixKrueger/Bismark/issues/652#issuecomment-2750781652
    This workaround should be re-evaluated when upgrading the methylseq pipeline */
   withName:BISMARK_ALIGN {

--- a/roles/nf-core/templates/site.config.j2
+++ b/roles/nf-core/templates/site.config.j2
@@ -30,6 +30,14 @@ process {
         time = { 2.d * task.attempt }
   }
 
+
+/* Temporary downgrade of bismark to work around the issue described here:
+   https://github.com/FelixKrueger/Bismark/issues/652#issuecomment-2750781652
+   This workaround should be re-evaluated when upgrading the methylseq pipeline */
+  withName:BISMARK_ALIGN {
+        container = "/vulpes/ngi/containers/biocontainers/quay.io-singularity-bismark-0.24.0--hdfd78af_0.img"
+    }
+
 }
 
 {% elif pipeline == 'ampliseq' %}


### PR DESCRIPTION
See comment in commit for background regarding this change. 

Risk analysis: There is a risk that this workaround is forgotten and that it causes issues (or just unnecessarily keeps us at an old bismark version) when upgrading the methylseq pipeline. To increase visibility we could (as suggested by @kjellinjonas) add this to a separate config that is added to the alias. I looked into that, but find this solution much cleaner. Adding a new config would require us to make changes in multiple places, making it hard to know which changes are connected to the workaround --> Increasing the risk of it being untouched and making the code complicated. Hence, I think this solution is good enough. Hopefully this config will be reviewed when updating the pipeline.

I have applied this change manually in:  `/vulpes/ngi/production/v25.05/conf/methylseq_upps.config` 

