### PR TITLE
Update to CheckQC v4.1.0 and update config

### DIFF
--- a/files/checkqc.config
+++ b/files/checkqc.config
@@ -1,4 +1,4 @@
-# Adapted from https://github.com/Molmed/checkQC/blob/v3.8.2/checkQC/default_config/config.yaml
+# Adapted from https://github.com/Molmed/checkQC/blob/v4.1.0/checkQC/default_config/config.yaml
 # For information about config usage, see http://checkqc.readthedocs.io/en/latest/#configuration-file
 
 # Use this section to provide configuration options to the parsers
@@ -9,6 +9,10 @@ parser_configurations:
     bcl2fastq_output_path: Unaligned
   SamplesheetParser:
     samplesheet_name: SampleSheet.csv
+  from_bclconvert:
+    reports_location: Reports
+
+default_view: illumina_data_view
 
 default_handlers:
   - name: UndeterminedPercentageHandler
@@ -41,6 +45,7 @@ hiseq2500_rapidhighoutput_v4:
       - name: ReadsPerSampleHandler
         warning: unknown
         error: 135 # 75 % of threshold for clusters pass filter
+    view: illumina_data_view
   100-111:
     handlers:
       - name: ClusterPFHandler
@@ -331,7 +336,7 @@ novaseqxplus_1.5B:
         warning: 800
         error: unknown
       - name: Q30Handler
-        warning: 90 
+        warning: 90
         error: unknown
       - name: ErrorRateHandler
         allow_missing_error_rate: False
@@ -411,7 +416,7 @@ novaseqxplus_10B:
         warning: 85
         error: unknown
       - name: ErrorRateHandler
-        allow_missing_error_rate: False 
+        allow_missing_error_rate: False
         warning: 5
         error: unknown
       - name: ReadsPerSampleHandler
@@ -597,3 +602,192 @@ iseq_v1:
       - name: ReadsPerSampleHandler
         warning: unknown
         error: 3
+
+nextseq500_high:
+  76:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 100
+        error: unknown
+      - name: Q30Handler
+        warning: 80
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 75
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+  151:
+      handlers:
+      - name: ClusterPFHandler
+        warning: 100
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 75
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+  301:
+      handlers:
+      - name: ClusterPFHandler
+        warning: 60
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 15
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+
+nextseq500_mid:
+  76:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 32
+        error: unknown
+      - name: Q30Handler
+        warning: 80
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 24
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+  151:
+      handlers:
+      - name: ClusterPFHandler
+        warning: 32
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 24
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+  301:
+      handlers:
+      - name: ClusterPFHandler
+        warning: 32
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 24
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+
+nextseq550_high:
+  76:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 100
+        error: unknown
+      - name: Q30Handler
+        warning: 80
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 75
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+  151:
+      handlers:
+      - name: ClusterPFHandler
+        warning: 100
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 75
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+  301:
+      handlers:
+      - name: ClusterPFHandler
+        warning: 100
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 75
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+
+nextseq550_mid:
+  76:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 32
+        error: unknown
+      - name: Q30Handler
+        warning: 80
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 24
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+  151:
+      handlers:
+      - name: ClusterPFHandler
+        warning: 32
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 24
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+  301:
+      handlers:
+      - name: ClusterPFHandler
+        warning: 32
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 24
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+

--- a/roles/arteria-checkqc-ws/defaults/main.yml
+++ b/roles/arteria-checkqc-ws/defaults/main.yml
@@ -2,4 +2,4 @@ arteria_service_name: arteria-checkqc-ws
 arteria_checkqc_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 checkqc_repo: https://github.com/Molmed/checkQC.git
-checkqc_version: v4.1.0-rc1
+checkqc_version: v4.1.0


### PR DESCRIPTION
Updates CheckQC to the production release of v4.1.0. Which is identical to v4.1.0-rc1 (the version tag being the exception) that was verified in the staging environment.

Unfortunately I realized that we had forgotten to update the SNP&SEQ adapted config used by both the checkqc and seqreports service. This should have been part of the verification. The new config was however tested in local tests of the new version, so I'm fairly confident no second round of verification is needed. 