### PR TITLE
crontab/supervisord: use full paths in crontabs

### DIFF
--- a/roles/func_accounts/templates/crontab.j2
+++ b/roles/func_accounts/templates/crontab.j2
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 
 {% if site == "upps" %}
 
-@reboot source $HOME/.bash_profile && supervisord -c {{ supervisord_conf }}
+@reboot source $HOME/.bash_profile && {{ ngi_pipeline_venv }}/bin/supervisord -c {{ supervisord_conf }}
 # restart supervisord if it has died for some reason
 11 * * * *      bash {{ ngi_resources }}/start_supervisord_{{ site }}.sh &> /dev/null
 

--- a/roles/func_accounts/templates/start_supervisord_site.sh.j2
+++ b/roles/func_accounts/templates/start_supervisord_site.sh.j2
@@ -9,6 +9,6 @@ fi
 
 # otherwise, let's start it up
 source ${HOME}/.bash_profile &> /dev/null
-supervisord -c {{ supervisord_conf }} &> /dev/null
+{{ ngi_pipeline_venv }}/bin/supervisord -c {{ supervisord_conf }} &> /dev/null
 exit $?
 


### PR DESCRIPTION
The automatic start of `supervisord` after a reboot isn't working, as we noticed these last couple of maintenance windows. I think it is because `cron` generally has a very sparse environment and `PATH` is minimal. In this PR, I modified the calls to `supervisord` to use the full path.