### PR TITLE
Bump arteria-delivery to release version

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v3.3.0-rc1
+arteria_delivery_version: v3.3.0
 
 arteria_delivery_wrapper: "{{ arteria_service_config_root }}/arteria-delivery_wrapper.sh"
 


### PR DESCRIPTION
This version bumps arteria-delivery version to the deployed version after testing the feature to add functionality to exclude runfolders from batch processing 