### PR TITLE
260122.526aeb2-bimonthly hotfixes

### DIFF
--- a/roles/arteria-sequencing-report-ws/defaults/main.yml
+++ b/roles/arteria-sequencing-report-ws/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 seqreport_service_repo: https://github.com/arteria-project/sequencing-report-service.git
-seqreport_service_version: v1.6.0-rc3
+seqreport_service_version: v1.6.0-rc4
 
 arteria_service_name: arteria-sequencing-report-ws
 arteria_sequencing_report_wrapper: "{{ arteria_service_config_root }}/arteria_sequencing_report_wrapper.sh"

--- a/roles/arteria-sequencing-report-ws/templates/arteria_sequencing_report_wrapper.sh.j2
+++ b/roles/arteria-sequencing-report-ws/templates/arteria_sequencing_report_wrapper.sh.j2
@@ -1,5 +1,7 @@
 #! /bin/bash -l
 
+source {{ ngi_pipeline_conf }}/sourceme_upps.sh
+
 export PATH={{ sw_path }}/nextflow:$PATH
 export NXF_HOME={{ nextflow_dest }}/workfiles
 export NXF_JAVA_HOME={{ nextflow_env.NXF_JAVA_HOME }}


### PR DESCRIPTION
This PR serves as a reminder of hotfixes applied to `260122.526aeb2-bimonthly`. This branch should be merged to bimonthly before bimonthly is merged into monthly. 

Changes:
- The current env is now sourced in the arteria-sequencing-report-service wrapper, to make sure the correct Nextflow parameters are available. 
- Update seqreports pipeline so that it can handle the new nextflow version and empty fastqs