### PR TITLE
Fixing demultiplex bclconvert config

### DIFF
--- a/files/checkqc.config
+++ b/files/checkqc.config
@@ -10,7 +10,7 @@ parser_configurations:
   SamplesheetParser:
     samplesheet_name: SampleSheet.csv
   from_bclconvert:
-    reports_location: Unaligned/Reports
+    reports_location: Unaligned/Stats
 
 default_view: illumina_data_view
 

--- a/files/checkqc.config
+++ b/files/checkqc.config
@@ -10,7 +10,7 @@ parser_configurations:
   SamplesheetParser:
     samplesheet_name: SampleSheet.csv
   from_bclconvert:
-    reports_location: Reports
+    reports_location: Unaligned/Reports
 
 default_view: illumina_data_view
 

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -84,7 +84,7 @@ process {
                 path: { "${params.outdir}/Unaligned/" },
                 mode: "link",
                 pattern: "output/Reports",
-                saveAs: {filename -> filename.split("/")[-1] }
+                saveAs: {filename ->  "Stats/${filename.minus('output/Reports')}" }
             ],
             [
                 // Gather and write InterOp files

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -69,21 +69,21 @@ process {
         publishDir = [
             [
                 path: { "${params.outdir}/Unaligned/" },
-                pattern: "bclconvert/output/**_S[1-9]*_*.fastq.gz",
+                pattern: "output/**_S[1-9]*_*.fastq.gz",
                 mode: "link",
-                saveAs: { filename -> filename.minus("bclconvert/output/") }
+                saveAs: { filename -> filename.minus("output/") }
             ],
             [
                 path: { "${params.outdir}/Unaligned/" },
-                pattern: "bclconvert/output/**Undetermined_S0_*.fastq.gz",
+                pattern: "output/**Undetermined_S0_*.fastq.gz",
                 mode: "link",
-                saveAs: { filename -> filename.minus("bclconvert/output/") }
+                saveAs: { filename -> filename.minus("output/") }
             ],
             [
                 // Gather and write Reports and Stats
                 path: { "${params.outdir}/Unaligned/" },
                 mode: "link",
-                pattern: "bclconvert/output/Reports",
+                pattern: "output/Reports",
                 saveAs: {filename -> filename.split("/")[-1] }
             ],
             [

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -84,7 +84,7 @@ process {
                 path: { "${params.outdir}/Unaligned/" },
                 mode: "link",
                 pattern: "output/Reports",
-                saveAs: {filename ->  "Stats/${filename.minus('output/Reports')}" }
+                saveAs: { filename ->  "Stats/${filename.minus('output/Reports')}" }
             ],
             [
                 // Gather and write InterOp files


### PR DESCRIPTION
It seems the reports are not been written with the current [config](https://github.com/NationalGenomicsInfrastructure/miarka-provision/blob/bimonthly/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2). I tried again (with execution id=69787c90c81b3b943ae541f0)and got the same error where projman filler could not find 200624_A00834_0183_BHMTFYDRXX/Reports/Quality_Metrics.csv'

This PR solves the error caused by the mismatch  in the specification of the Reports folder? i.e [checkqc_config](https://github.com/NationalGenomicsInfrastructure/miarka-provision/blob/9ffd4ef67c1a89b4fc3612a0ba2a2e5259495819/files/checkqc.config#L13) specifies <Runfolder>/Reports while [demultiplex config](https://github.com/NationalGenomicsInfrastructure/miarka-provision/blob/526aeb2adec9eaaa5e9c5dd209a172332b9c3c8a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2#L82C12-L88C15) specifies <Runfolder>/Unaligned/Reports

None of these folders have the report files and thus making projman_filler fail

This PR also corrects the demultiplex config to look for report files from output/Reports and not bclconvert/output/Reports as seen [here](https://github.com/NationalGenomicsInfrastructure/miarka-provision/blob/526aeb2adec9eaaa5e9c5dd209a172332b9c3c8a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2#L86) as reports are only found if path to look from is output/Reports (tested in miarka2)
