### PR TITLE
kong: update version and increase timeouts for all services

### DIFF
--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Versions
-tarzan_kong_version: "2.6.0"
+tarzan_kong_version: "3.9.1"
 
 # Directories
 tarzan_root_dir: "{{ sw_path }}/tarzan"
@@ -20,10 +20,10 @@ tarzan_host_name: "miarka1.uppmax.uu.se"
 tarzan_start_script: "{{ tarzan_conf_dir }}/start_kong.sh"
 
 # Singularity image
-tarzan_singularity_image_file: "kong-{{ tarzan_kong_version }}-centos.sif"
+tarzan_singularity_image_file: "kong-{{ tarzan_kong_version }}.sif"
 tarzan_singularity_image_file_src: "{{ deployment_static_resources }}/{{ tarzan_singularity_image_file }}"
 tarzan_singularity_image_file_dest: "{{ ngi_containers }}/kong/{{ tarzan_singularity_image_file }}"
-tarzan_singularity_image_sha1: "0a6ff9026711cbd5662af0c37dcdfab0611c5741"
+tarzan_singularity_image_sha1: "7d3dcabc1cb6c9cab50d29d2778c6eca9a4b843c"
 
 # Singularity container
 tarzan_singularity_container_name: "kong-{{ deployment_environment }}"

--- a/roles/tarzan/files/kong.def
+++ b/roles/tarzan/files/kong.def
@@ -1,3 +1,3 @@
 Bootstrap: docker
-From: kong:2.6.0-centos
+From: kong:3.9.1
 Includecmd: no

--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -5,6 +5,9 @@ services:
   - name: arteria_checksum
     host: localhost
     port: {{ arteria_checksum_port }}
+    connect_timeout: 600000
+    read_timeout: 600000
+    write_timeout: 600000
     routes:
     - paths:
       - /arteria_checksum
@@ -24,6 +27,9 @@ services:
   - name: arteria_archive
     host: localhost
     port: {{ archive_upload_port }}
+    connect_timeout: 600000
+    read_timeout: 600000
+    write_timeout: 600000
     routes:
     - paths:
       - /arteria_archive
@@ -32,6 +38,9 @@ services:
   - name: arteria_archive_verify
     host: localhost
     port: {{ archive_verify_port }}
+    connect_timeout: 600000
+    read_timeout: 600000
+    write_timeout: 600000
     routes:
     - paths:
       - /verify
@@ -40,6 +49,9 @@ services:
   - name: arteria_sequencing_reports
     host: localhost
     port: {{ seqreport_service_port }}
+    connect_timeout: 600000
+    read_timeout: 600000
+    write_timeout: 600000
     routes:
     - paths:
       - /seqreports
@@ -48,6 +60,9 @@ services:
   - name: arteria_checkqc
     host: localhost
     port: {{ checkqc_service_port }}
+    connect_timeout: 600000
+    read_timeout: 600000
+    write_timeout: 600000
     routes:
     - paths:
       - /checkqc


### PR DESCRIPTION
Description:
Updates Kong to 3.9.1. I have built the container and put it on Miarka3.
Also, I updated the timeout limits for all services (previously this was only set for arteria-delivery), to avoid `504 Gateway Timeout` errors. 

Risk analysis:
While I could deploy this version on Miarka3, I could not start Kong and verify that the config values still are compatible. We will have to test in staging. We can always revert to the old version if we don't get it to work. 

Validation procedure:
Run ngi_uu_workflow in staging env. 