### PR TITLE
Update list of files to exclude from tarball

### DIFF
--- a/roles/archive-upload-ws/defaults/main.yml
+++ b/roles/archive-upload-ws/defaults/main.yml
@@ -15,4 +15,4 @@ archive_upload_cores_to_use: 2
 archive_upload_whitelisted_warnings: ["ANS1809W", "ANS2042W", "ANS2250W"]
 archive_upload_exclude_dirs: []
 archive_upload_exclude_extensions: [".bam"]
-archive_upload_exclude_from_tarball: []
+archive_upload_exclude_from_tarball: ["*.gz", "*.zip", "*.bin"]


### PR DESCRIPTION
Description:
This PR updates the archive_upload config so that *.gz", "*.zip" and "*.bin" files are excluded from the tarball. This makes the compress archive task faster. Also, previously the service would make a compressed archive of files that already was compressed archives which is totally unnecessary. 

Risk analysis: 
Some MultiQC files are compressed and would perhaps benefit from being added to an archive to reduce the number of files. It is however possible for the operator to in such cases make a tarball of such directories manually before invoking the workflow.

Validation procedure:
Applied as a hotfix in v16.02 and worked as expected. 