### PR TITLE
Bimonthly merge

### DIFF
--- a/files/checkqc.config
+++ b/files/checkqc.config
@@ -10,7 +10,7 @@ parser_configurations:
   SamplesheetParser:
     samplesheet_name: SampleSheet.csv
   from_bclconvert:
-    reports_location: Unaligned/Reports
+    reports_location: Unaligned/Stats
 
 default_view: illumina_data_view
 

--- a/files/checkqc.config
+++ b/files/checkqc.config
@@ -10,7 +10,7 @@ parser_configurations:
   SamplesheetParser:
     samplesheet_name: SampleSheet.csv
   from_bclconvert:
-    reports_location: Reports
+    reports_location: Unaligned/Reports
 
 default_view: illumina_data_view
 

--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -47,7 +47,7 @@ ngi_resources: "{{ root_path }}/resources/"
 sarek_tag: "3.5.1"
 sarek_dest: "{{ sw_path }}/sarek/{{ sarek_tag | regex_replace('[^0-9a-zA-Z_]+', '_') }}"
 
-rnaseq_tag: "v3.12.0_ngi_v1-rc1"
+rnaseq_tag: "v3.12.0_ngi_v2"
 rnaseq_dest: "{{ sw_path }}/rnaseq/{{ rnaseq_tag | regex_replace('[^0-9a-zA-Z_]+', '_')  }}"
 
 demultiplex_tag: "1.7.0"

--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -50,7 +50,7 @@ sarek_dest: "{{ sw_path }}/sarek/{{ sarek_tag | regex_replace('[^0-9a-zA-Z_]+', 
 rnaseq_tag: "v3.12.0_ngi_v1-rc1"
 rnaseq_dest: "{{ sw_path }}/rnaseq/{{ rnaseq_tag | regex_replace('[^0-9a-zA-Z_]+', '_')  }}"
 
-demultiplex_tag: "1.5.4"
+demultiplex_tag: "1.7.0"
 
 # File with tools/software version in the deployed env
 deployed_tool_versions: "{{ ngi_resources }}/deployed_tools.{{ site }}.version"

--- a/roles/arteria-checkqc-ws/defaults/main.yml
+++ b/roles/arteria-checkqc-ws/defaults/main.yml
@@ -2,4 +2,4 @@ arteria_service_name: arteria-checkqc-ws
 arteria_checkqc_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 checkqc_repo: https://github.com/Molmed/checkQC.git
-checkqc_version: v4.1.0
+checkqc_version: v4.1.1-rc1

--- a/roles/arteria-checksum-ws/defaults/main.yml
+++ b/roles/arteria-checksum-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_checksum_repo: https://github.com/arteria-project/arteria-checksum.git
-arteria_checksum_version: v1.0.4
+arteria_checksum_version: v1.1.0-rc1
 
 # These values will be appended with production and staging specific
 # paths in the tasks.

--- a/roles/arteria-checksum-ws/tasks/1_install.yml
+++ b/roles/arteria-checksum-ws/tasks/1_install.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: create virtual python env for arteria-checksum
-  shell: "conda create --name {{ arteria_service_name }} python=2.7"
+  shell: "conda create --name {{ arteria_service_name }} python=3.11"
   args:
     creates: "{{ arteria_service_env_root }}"
 

--- a/roles/arteria-checksum-ws/templates/checksum_app.config.j2
+++ b/roles/arteria-checksum-ws/templates/checksum_app.config.j2
@@ -4,9 +4,8 @@
 
 monitored_directory: "{{ arteria_checksum_monitored_path }}"
 
-# Used when running with localq runner to determine the maximum number of
-# used for running checksums
-number_of_cores: "{{ arteria_checksum_cores_to_use }}"
+# Determine how many past and active jobs should be kept in memory
+history_len: 100
 
 # Path to the md5sum logs
 md5_log_directory: "{{ arteria_checksum_md5sum_log_dir  }}"

--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v3.2.2-rc2
+arteria_delivery_version: v3.4.0-rc1
 
 arteria_delivery_wrapper: "{{ arteria_service_config_root }}/arteria-delivery_wrapper.sh"
 

--- a/roles/arteria-sequencing-report-ws/defaults/main.yml
+++ b/roles/arteria-sequencing-report-ws/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 seqreport_service_repo: https://github.com/arteria-project/sequencing-report-service.git
-seqreport_service_version: v1.5.2
+seqreport_service_version: v1.6.0-rc1
 
 arteria_service_name: arteria-sequencing-report-ws
 arteria_sequencing_report_wrapper: "{{ arteria_service_config_root }}/arteria_sequencing_report_wrapper.sh"

--- a/roles/arteria-sequencing-report-ws/defaults/main.yml
+++ b/roles/arteria-sequencing-report-ws/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 seqreport_service_repo: https://github.com/arteria-project/sequencing-report-service.git
-seqreport_service_version: v1.6.0-rc1
+seqreport_service_version: v1.6.0-rc2
 
 arteria_service_name: arteria-sequencing-report-ws
 arteria_sequencing_report_wrapper: "{{ arteria_service_config_root }}/arteria_sequencing_report_wrapper.sh"

--- a/roles/arteria-sequencing-report-ws/defaults/main.yml
+++ b/roles/arteria-sequencing-report-ws/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 seqreport_service_repo: https://github.com/arteria-project/sequencing-report-service.git
-seqreport_service_version: v1.6.0-rc2
+seqreport_service_version: v1.6.0-rc3
 
 arteria_service_name: arteria-sequencing-report-ws
 arteria_sequencing_report_wrapper: "{{ arteria_service_config_root }}/arteria_sequencing_report_wrapper.sh"

--- a/roles/arteria-sequencing-report-ws/defaults/main.yml
+++ b/roles/arteria-sequencing-report-ws/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 seqreport_service_repo: https://github.com/arteria-project/sequencing-report-service.git
-seqreport_service_version: v1.6.0-rc3
+seqreport_service_version: v1.6.0-rc4
 
 arteria_service_name: arteria-sequencing-report-ws
 arteria_sequencing_report_wrapper: "{{ arteria_service_config_root }}/arteria_sequencing_report_wrapper.sh"

--- a/roles/arteria-sequencing-report-ws/tasks/install.yml
+++ b/roles/arteria-sequencing-report-ws/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: create virtual python env for sequencing report service
-  shell: "conda create --name {{ arteria_service_name }} python=3.8"
+  shell: "conda create --name {{ arteria_service_name }} python=3.13"
   args: 
     creates: "{{ arteria_service_env_root }}"
 

--- a/roles/arteria-sequencing-report-ws/tasks/install.yml
+++ b/roles/arteria-sequencing-report-ws/tasks/install.yml
@@ -11,13 +11,6 @@
     dest: "{{ arteria_service_src_path }}"
     version: "{{ seqreport_service_version }}"
 
-- name: install sequencing report service requirements
-  pip:
-    requirements: "{{ arteria_service_src_path }}/requirements/prod"
-    chdir: "{{ arteria_service_src_path }}"
-    executable: "{{ arteria_service_env_root }}/bin/pip"
-    state: present
-
 - name: get checksum pipeline from git
   git:
     repo: "{{ sis_style_checksums_repo }}"

--- a/roles/arteria-sequencing-report-ws/templates/arteria_sequencing_report_wrapper.sh.j2
+++ b/roles/arteria-sequencing-report-ws/templates/arteria_sequencing_report_wrapper.sh.j2
@@ -1,5 +1,7 @@
 #! /bin/bash -l
 
+source {{ ngi_pipeline_conf }}/sourceme_upps.sh
+
 export PATH={{ sw_path }}/nextflow:$PATH
 export NXF_HOME={{ nextflow_dest }}/workfiles
 export NXF_JAVA_HOME={{ nextflow_env.NXF_JAVA_HOME }}

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -84,7 +84,7 @@ process {
                 path: { "${params.outdir}/Unaligned/" },
                 mode: "link",
                 pattern: "output/Reports",
-                saveAs: {filename -> filename.split("/")[-1] }
+                saveAs: {filename ->  "Stats/${filename.minus('output/Reports')}" }
             ],
             [
                 // Gather and write InterOp files

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -69,21 +69,21 @@ process {
         publishDir = [
             [
                 path: { "${params.outdir}/Unaligned/" },
-                pattern: "bclconvert/output/**_S[1-9]*_*.fastq.gz",
+                pattern: "output/**_S[1-9]*_*.fastq.gz",
                 mode: "link",
-                saveAs: { filename -> filename.minus("bclconvert/output/") }
+                saveAs: { filename -> filename.minus("output/") }
             ],
             [
                 path: { "${params.outdir}/Unaligned/" },
-                pattern: "bclconvert/output/**Undetermined_S0_*.fastq.gz",
+                pattern: "output/**Undetermined_S0_*.fastq.gz",
                 mode: "link",
-                saveAs: { filename -> filename.minus("bclconvert/output/") }
+                saveAs: { filename -> filename.minus("output/") }
             ],
             [
                 // Gather and write Reports and Stats
                 path: { "${params.outdir}/Unaligned/" },
                 mode: "link",
-                pattern: "bclconvert/output/Reports",
+                pattern: "output/Reports",
                 saveAs: {filename -> filename.split("/")[-1] }
             ],
             [

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -59,4 +59,39 @@ process {
             ],
         ]
     }
+    withName: BCLCONVERT {
+        time = '72h'
+        cpus = 24
+        memory = '147G'
+        ext.args = {[
+            params.ext_args ? "${params.ext_args}" : "",
+        ].join(" ").trim()}
+        publishDir = [
+            [
+                path: { "${params.outdir}/Unaligned/" },
+                pattern: "bclconvert/output/**_S[1-9]*_*.fastq.gz",
+                mode: "link",
+                saveAs: { filename -> filename.minus("bclconvert/output/") }
+            ],
+            [
+                path: { "${params.outdir}/Unaligned/" },
+                pattern: "bclconvert/output/**Undetermined_S0_*.fastq.gz",
+                mode: "link",
+                saveAs: { filename -> filename.minus("bclconvert/output/") }
+            ],
+            [
+                // Gather and write Reports and Stats
+                path: { "${params.outdir}/Unaligned/" },
+                mode: "link",
+                pattern: "bclconvert/output/Reports",
+                saveAs: {filename -> filename.split("/")[-1] }
+            ],
+            [
+                // Gather and write InterOp files
+                path: { "${params.outdir}" },
+                mode: "link",
+                pattern: "**.bin",
+            ],
+        ]
+    }
 }

--- a/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
+++ b/roles/arteria-sequencing-report-ws/templates/nextflow_configs/demultiplex.config.j2
@@ -84,7 +84,7 @@ process {
                 path: { "${params.outdir}/Unaligned/" },
                 mode: "link",
                 pattern: "output/Reports",
-                saveAs: {filename ->  "Stats/${filename.minus('output/Reports')}" }
+                saveAs: { filename ->  "Stats/${filename.minus('output/Reports')}" }
             ],
             [
                 // Gather and write InterOp files

--- a/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
+++ b/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
@@ -7,6 +7,7 @@ main_workflow_path: "{{ sw_path }}/demultiplex/{{ demultiplex_tag | regex_replac
 # - {runfolder_path}
 # - {current_year}
 # - {input_samplesheet_path}
+# - {demultiplexer}
 nextflow_parameters:
   config: "{{ arteria_service_nextflow_config_dir }}/demultiplex.config"
   profile: "singularity,uppmax"
@@ -19,7 +20,7 @@ pipeline_parameters:
   input: "{input_samplesheet_path}"
   outdir: "{runfolder_path}"
   project: {{uppmax_project}}
-  demultiplexer: "bcl2fastq"
+  demultiplexer: "{{demultiplexer}}"
   skip_tools: "samshee,checkqc,fastp,falco,md5sum,kraken,multiqc"
 input_samplesheet_content: |
   id,samplesheet,lane,flowcell

--- a/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
+++ b/roles/arteria-sequencing-report-ws/templates/pipeline_configs/demultiplex.yml.j2
@@ -20,7 +20,7 @@ pipeline_parameters:
   input: "{input_samplesheet_path}"
   outdir: "{runfolder_path}"
   project: {{uppmax_project}}
-  demultiplexer: "{{demultiplexer}}"
+  demultiplexer: "{demultiplexer}"
   skip_tools: "samshee,checkqc,fastp,falco,md5sum,kraken,multiqc"
 input_samplesheet_content: |
   id,samplesheet,lane,flowcell

--- a/roles/arteria-sequencing-report-ws/templates/pipeline_configs/seqreports.yml.j2
+++ b/roles/arteria-sequencing-report-ws/templates/pipeline_configs/seqreports.yml.j2
@@ -7,6 +7,7 @@ main_workflow_path: "{{arteria_service_src_path}}/seqreports/main.nf"
 # - {runfolder_path}
 # - {current_year}
 # - {input_samplesheet_path}
+# - {demultiplexer}
 nextflow_parameters:
   config: "{{arteria_service_src_path}}/seqreports/nextflow.config"
   profile: {{seqreports_nf_profile}}
@@ -23,3 +24,4 @@ pipeline_parameters:
   checkqc_config: "{{arteria_service_config_root}}/checkqc.config"
   result_dir: "{runfolder_path}/seqreports"
   script_dir: "{{arteria_service_src_path}}/seqreports/bin/"
+  demultiplexer: "{{demultiplexer}}"

--- a/roles/arteria-sequencing-report-ws/templates/pipeline_configs/seqreports.yml.j2
+++ b/roles/arteria-sequencing-report-ws/templates/pipeline_configs/seqreports.yml.j2
@@ -24,4 +24,4 @@ pipeline_parameters:
   checkqc_config: "{{arteria_service_config_root}}/checkqc.config"
   result_dir: "{runfolder_path}/seqreports"
   script_dir: "{{arteria_service_src_path}}/seqreports/bin/"
-  demultiplexer: "{{demultiplexer}}"
+  demultiplexer: "{demultiplexer}"

--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -1,8 +1,8 @@
 java_home: /sw/comp/java/OpenJDK_17+35/miarka/
 nextflow_java: "{{ java_home }}"
-nextflow_version_tag: 24.10.4
+nextflow_version_tag: 25.10.2
 nextflow_download_url: https://github.com/nextflow-io/nextflow/releases/download/v{{ nextflow_version_tag }}/nextflow
-nf_schema_version: 2.1.1
+nf_schema_version: 2.5.1
 nextflow_local_env:
   NXF_HOME: "{{ nextflow_dest }}/workfiles"
   NXF_OPTS: -Xms1g -Xmx3500m

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -37,7 +37,7 @@ pipelines:
     # TODO Evaluate if workaround implemented in
     # https://github.com/NationalGenomicsInfrastructure/miarka-provision/pull/340
     # can be removed when upgrading the methylseq pipeline
-    release: 3.0.0
+    release: 4.2.0
     container_dir: "{{ biocontainers_dirname }}"
     extra_parameters:
       references:

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -71,6 +71,9 @@ pipelines:
   - name: demultiplex
     release: "{{ demultiplex_tag }}"
     container_dir: "{{ biocontainers_dirname }}"
+  - name: pixelator
+    release: 2.2.0
+    container_dir: "{{ biocontainers_dirname }}"
 
 nf_core_delivery_readmes:
   sarek:

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -72,7 +72,7 @@ pipelines:
     release: "{{ demultiplex_tag }}"
     container_dir: "{{ biocontainers_dirname }}"
   - name: pixelator
-    release: 2.2.0
+    release: 2.3.0
     container_dir: "{{ biocontainers_dirname }}"
 
 nf_core_delivery_readmes:


### PR DESCRIPTION
This adds the bimonthly changes to the monthly branch. 

It contains the following changes: 

- rnaseq pipeline updated to  v3.12.0_ngi_v2
- pixelator v2.3.0 added
- demultiplex pipeline updated to 1.7.0
- Methylseq bumped to 4.2.0
- Update Nextflow to 25.10.2 and nf_schema to 2.5.1
- Arteria BCL Convert changes:
    - checkqc updated v4.1.1-rc1
    - arteria-checksum updated to v1.1.0-rc1
    - arteria-delivery updated to v3.4.0-rc1
    - arteria-sequencing-report-service updated to v1.6.0-rc4
    
   All BPA pipelines passed verification.
   There are still some minor BCL Convert related issues with the Arteria microservices (these are documented in internal SNP&SEQ documents), but all bcl2fastq tests pass. These issues will be addressed in upcoming verifications. 