### PR TITLE
Update sarek to 3.8.1 + nextflow plugins

### DIFF
--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -44,7 +44,7 @@ ngi_pipeline_venv: "{{ anaconda_path }}/envs/{{ NGI_venv_name }}"
 ngi_pipeline_conf: "{{ root_path }}/conf/"
 ngi_resources: "{{ root_path }}/resources/"
 
-sarek_tag: "3.5.1"
+sarek_tag: "3.8.1"
 sarek_dest: "{{ sw_path }}/sarek/{{ sarek_tag | regex_replace('[^0-9a-zA-Z_]+', '_') }}"
 
 rnaseq_tag: "v3.12.0_ngi_v2"

--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -2,7 +2,7 @@ java_home: /sw/comp/java/OpenJDK_17+35/miarka/
 nextflow_java: "{{ java_home }}"
 nextflow_version_tag: 25.10.2
 nextflow_download_url: https://github.com/nextflow-io/nextflow/releases/download/v{{ nextflow_version_tag }}/nextflow
-nf_schema_version: 2.5.1
+nf_schema_version: 2.6.1
 nextflow_local_env:
   NXF_HOME: "{{ nextflow_dest }}/workfiles"
   NXF_OPTS: -Xms1g -Xmx3500m
@@ -23,8 +23,11 @@ nextflow_plugins:
   - name: nf-validation
     version: 1.1.2
   - name: nf-prov
-    version: 1.2.1
+    version: 1.2.2
   - name: nf-tower
     version: 1.6.3
   - name: nf-schema # Will replace nf-validation once we update all our pipelines
     version: "{{ nf_schema_version }}"
+  - name: nf-core-utils
+    version: 0.4.0
+


### PR DESCRIPTION
This PR updates sarek to 3.8.1 and updates the pipeline's nextflow plugin dependencies. 

Validatation procedure:
A validation report will be made for Sarek. We should also verify other BPA pipelines to make sure that the updated plugins do not break anything. 