### PR TITLE
Update FASTQ delivery readmes so they work for BCL Convert as well

### DIFF
--- a/roles/arteria-delivery-ws/files/README.md
+++ b/roles/arteria-delivery-ws/files/README.md
@@ -11,17 +11,17 @@ This delivery includes sequencing data in FASTQ format, a summary report created
     ├── SampleSheet.csv
     ├── <runfolder>_<project>_multiqc_report_data.zip
     ├── <runfolder>_<project>_multiqc_report.html
-    ├── <Sample1 id>
-        ├── <sample1 name>_<sample number>_R1_001.fastq.gz
-        └── <sample1 name>_<sample number>_R2_001.fastq.gz
-    ├── <Sample2 id>
-        ├── <sample2 name>_<sample number>_R1_001.fastq.gz
-        └── <sample2 name>_<sample number>_R2_001.fastq.gz
+    ├── <sample1 id>
+        ├── <sample1 id/name>_<sample number>_R1_001.fastq.gz
+        └── <sample1 id/name>_<sample number>_R2_001.fastq.gz
+    ├── <sample2 id>
+        ├── <sample2 id/name>_<sample number>_R1_001.fastq.gz
+        └── <sample2 id/name>_<sample number>_R2_001.fastq.gz
      :
      :
-    └── <SampleN id>
-        ├── <sampleN name>_<sample number>_R1_001.fastq.gz
-        └── <sampleN name>_<sample number>_R2_001.fastq.gz
+    └── <sampleN id>
+        ├── <sampleN id/name>_<sample number>_R1_001.fastq.gz
+        └── <sampleN id/name>_<sample number>_R2_001.fastq.gz
 ```
 
 ## Verifying file integrity

--- a/roles/arteria-delivery-ws/files/README.undetermined.md
+++ b/roles/arteria-delivery-ws/files/README.undetermined.md
@@ -2,7 +2,7 @@
 
 This delivery includes sequencing data in FASTQ format, a summary report created with MultiQC, checksums and a copy of the sample sheet used for demultiplexing.
 
-The FASTQ files named "Undetermined" contains reads that could not be assigned to a sample. Note that in cases where demultiplexing is expected to fail e.g. when inline barcode are used, the Undetermined FASTQs are the main data source. There might be some reads assigned to individual sample(s) (i.e. <Sample1 id> ... <SampleN id>) by chance. These can be disregarded.
+The FASTQ files named "Undetermined" contains reads that could not be assigned to a sample. Note that in cases where demultiplexing is expected to fail e.g. when inline barcode are used, the Undetermined FASTQs are the main data source. There might be some reads assigned to individual sample(s) (i.e. <sample1 id> ... <sampleN id>) by chance. These can be disregarded.
 
 ## Delivery structure
 ```
@@ -13,17 +13,17 @@ The FASTQ files named "Undetermined" contains reads that could not be assigned t
     ├── SampleSheet.csv
     ├── <runfolder>_<project>_multiqc_report_data.zip
     ├── <runfolder>_<project>_multiqc_report.html
-    ├── <Sample1 id>
-        ├── <sample1 name>_<sample number>_R1_001.fastq.gz
-        └── <sample1 name>_<sample number>_R2_001.fastq.gz
-    ├── <Sample2 id>
-        ├── <sample2 name>_<sample number>_R1_001.fastq.gz
-        └── <sample2 name>_<sample number>_R2_001.fastq.gz
+    ├── <sample1 id>
+        ├── <sample1 id/name>_<sample number>_R1_001.fastq.gz
+        └── <sample1 id/name>_<sample number>_R2_001.fastq.gz
+    ├── <sample2 id>
+        ├── <sample2 id/name>_<sample number>_R1_001.fastq.gz
+        └── <sample2 id/name>_<sample number>_R2_001.fastq.gz
      :
      :
-    └── <SampleN id>
-        ├── <sampleN name>_<sample number>_R1_001.fastq.gz
-        └── <sampleN name>_<sample number>_R2_001.fastq.gz
+    └── <sampleN id>
+        ├── <sampleN id/name>_<sample number>_R1_001.fastq.gz
+        └── <sampleN id/name>_<sample number>_R2_001.fastq.gz
     └── Undetermined
         ├── Undetermined_<sample number>_<lane>_R1.001.fastq.gz
         ├── Undetermined_<sample number>_<lane>_R2.001.fastq.gz


### PR DESCRIPTION
**Description** 
Updates the arteria-delivery FASTQ delivery README:s so that they are correct for data processed with BCL Convert as well. 

**Risk analysis**
Low risk, minor changes to README:s. 

**Validation procedure**
Validation is not needed for this change. 