### PR TITLE
Warn about squash on persistent branches and clarify where create static content 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Below are the main tasks and commands to perform for a staging or production dep
 * Create a change log
     * This usually means [comparing main to monthly](https://github.com/NationalGenomicsInfrastructure/miarka-provision/compare/main...monthly) and list all changes that will be introduced. Save this list locally.
 *  Create the new release **[Production deployment only]**
-    * Create a PR to merge monthly into main
+    * Create a PR to merge monthly into main (NOTE: Do NOT squash commits before merging persistent branches (monthly/bimonthly/main), this will mess up the deployment flow)
     * When merged, create a release. The tag should be `v[YY].[MM]`. For example `v26.03` if the deployment is done in March 2026. The tag should point to the current head of the main branch. Add the change log to the release description.
 * Deploy
     * Log on to Miarka3 and perform the following commands:
@@ -46,7 +46,7 @@ ssh miarka2.uppmax.uu.se exit
 ansible-playbook -i inventory.yml sync.yml -e deployment_environment=[staging / production]
 ```
 * Create site-specific directories
-    * Run the following as the func account of your site (and ask a deployment team member of other site to run it as theirs):
+    * Run the following on miarka1 (production) or miarka2 (staging) as the func account of your site (and ask a deployment team member of other site to run it as theirs):
 ```
 /vulpes/ngi/[staging / production]/latest/resources/create_static_contents_[upps / sthlm].sh
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,6 +6,8 @@ Production deployments on the monthly release cycle are done on the last Monday 
 
 Stage deployments from the bimonthly branch can be made outside of the monthly release cycle. The changes on the bimonthly branch would generally be pulled to the monthly branch and deployed to production in the monthly release cycle once all validations are complete.
 
+Important: It is very important to not squash commits before mergning persistent branches (monthly/bimonthly/main). This is however encouraged when merging feature branches that should be deleted after merge.
+
 ## Requirements
 
 The git repository does not contain any sensitive credentials. Instead, these need to be specified in the correct file under `env_vars` and `env_secrets` in the checked out `miarka-provision` folder you will be deploying from. In practice, you will probably copy these files from `/vulpes/ngi/deploy` or from the last deployment and only modify them when something needs changing.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@ Production deployments on the monthly release cycle are done on the last Monday 
 
 Stage deployments from the bimonthly branch can be made outside of the monthly release cycle. The changes on the bimonthly branch would generally be pulled to the monthly branch and deployed to production in the monthly release cycle once all validations are complete.
 
-Important: It is very important to not squash commits before mergning persistent branches (monthly/bimonthly/main). This is however encouraged when merging feature branches that should be deleted after merge.
+Important: It is very important to not squash commits before merging persistent branches (monthly/bimonthly/main). This is however encouraged when merging feature branches that should be deleted after merge.
 
 ## Requirements
 


### PR DESCRIPTION
This PR addresses two issues discovered in connection with deployments:
- It is very important to not squash commits before merging persistent branches. This is however encouraged when merging feature branches that should be deleted after merge. This have been added to the docs
- Since the create_static_content script has a step that reloads the crontab for the func account, it is important that it is run on the correct node. This has been clarified in the deployment checklist. 