### PR TITLE
Try to start Kong hourly if it is not running

### DIFF
--- a/roles/tarzan/tasks/install_tarzan.yml
+++ b/roles/tarzan/tasks/install_tarzan.yml
@@ -41,10 +41,16 @@
     dest: "{{ tarzan_singularity_image_file_dest }}"
     checksum: "{{ tarzan_singularity_image_sha1 }}"
 
-- name: modify crontab to start kong
+- name: modify crontab to start kong after reboot
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/crontab_{{ site }}"
-    line: '@reboot sleep 60 && source $HOME/.bash_profile && {{ tarzan_start_script }} &> /dev/null'
+    line: '@reboot sleep 120 && source $HOME/.bash_profile && {{ tarzan_start_script }} &> /dev/null'
+    backup: no
+
+- name: add hourly check to crontab to start Kong if it is not running
+  lineinfile:
+    dest: "{{ ngi_pipeline_conf }}/crontab_{{ site }}"
+    line: '11 * * * * source $HOME/.bash_profile && {{ tarzan_start_script }} &> /dev/null'
     backup: no
 
 - name: add static folders to be created

--- a/roles/tarzan/templates/start_kong.sh.j2
+++ b/roles/tarzan/templates/start_kong.sh.j2
@@ -1,6 +1,11 @@
-#!/bin/bash
+#! /bin/bash -l
 
-/usr/bin/singularity instance stop -F {{ tarzan_singularity_container_name }} 2>/dev/null || echo "No singularity instance '{{ tarzan_singularity_container_name }}' running... ignoring"
+# check if kong is already running
+if [ ! -z "`/usr/bin/singularity instance list | grep {{ tarzan_singularity_container_name }}`" ]
+then
+  # if it is running, we'll just exit politely
+  exit 0
+fi
 
 /usr/bin/singularity instance start \
 --bind "{{ tarzan_server_conf_file }}:{{ tarzan_singularity_container_server_conf_file }}" \


### PR DESCRIPTION
This PR potentially solves an issue we experience with Kong not being started after reboot. 

Since we never have any issues with supervisord, I decided to update the start script to have the same approach as that service, namely: Check if Kong process is running, if yes, exit quietly. 

We used to have a cron job that RESTARTED Kong every hour, but that caused issues when communication with our web services. Hopefully this solution will work. 

Already applied as a hotfix in v26.04