### PR TITLE
Dataops 1539 add olink role

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -100,6 +100,7 @@
     - { role: archive-verify-ws, tags: archive-verify }
     - { role: nf-core, tags: nf-core }
     - { role: kraken2, tags: kraken2 }
+    - { role: arteria-olink, tags: arteria-olink }
 
   tasks:
 

--- a/roles/arteria-olink/defaults/main.yml
+++ b/roles/arteria-olink/defaults/main.yml
@@ -6,5 +6,4 @@ olink_ngs2counts_dir: "/vulpes/ngi/containers/ngs2counts"
 olink_ngs2counts_default: "6.2.0"
 
 olink_ngs2counts_nf_workflow: "https://github.com/Molmed/ngs2counts_nextflow.git"
-# TODO update when ready
-olink_ngs2counts_nf_workflow_version: "ece36a9b50fb4371aad16d8a357766e46c1bb0ca"
+olink_ngs2counts_nf_workflow_version: "1.0.0-rc1"

--- a/roles/arteria-olink/defaults/main.yml
+++ b/roles/arteria-olink/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+arteria_service_name: arteria-olink
+arteria_olink_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
+
+olink_ngs2counts_dir: "/vulpes/ngi/containers/ngs2counts"
+olink_ngs2counts_latest: ""
+olink_ngs2counts_default: ""
+
+olink_ngs2counts_nf_workflow: "https://github.com/Molmed/ngs2counts_nextflow.git"
+olink_ngs2counts_nf_workflow_version: ""

--- a/roles/arteria-olink/defaults/main.yml
+++ b/roles/arteria-olink/defaults/main.yml
@@ -3,7 +3,7 @@ arteria_service_name: arteria-olink
 arteria_olink_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 olink_ngs2counts_dir: "/vulpes/ngi/containers/ngs2counts"
-olink_ngs2counts_default: "6.2.0"
+olink_ngs2counts_default: "6.2.2"
 
 olink_ngs2counts_nf_workflow: "https://github.com/Molmed/ngs2counts_nextflow.git"
 olink_ngs2counts_nf_workflow_version: "1.0.0-rc1"

--- a/roles/arteria-olink/defaults/main.yml
+++ b/roles/arteria-olink/defaults/main.yml
@@ -3,8 +3,8 @@ arteria_service_name: arteria-olink
 arteria_olink_service_log: "{{ arteria_service_log_dir }}/{{ arteria_service_name }}.log"
 
 olink_ngs2counts_dir: "/vulpes/ngi/containers/ngs2counts"
-olink_ngs2counts_latest: ""
-olink_ngs2counts_default: ""
+olink_ngs2counts_default: "6.2.0"
 
 olink_ngs2counts_nf_workflow: "https://github.com/Molmed/ngs2counts_nextflow.git"
-olink_ngs2counts_nf_workflow_version: ""
+# TODO update when ready
+olink_ngs2counts_nf_workflow_version: "ece36a9b50fb4371aad16d8a357766e46c1bb0ca"

--- a/roles/arteria-olink/meta/main.yml
+++ b/roles/arteria-olink/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - { role: setup_base_config, tags: setup_base_config }

--- a/roles/arteria-olink/tasks/main.yml
+++ b/roles/arteria-olink/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: Ensure {{ arteria_service_name }} sw dir exists
+  file:
+    state: directory
+    path: "{{ arteria_service_src_path }}"
+
 - name: Create ngs2counts symlink
   file:
     src: "{{ olink_ngs2counts_dir }}/ngs2counts-{{ olink_ngs2counts_default }}"

--- a/roles/arteria-olink/tasks/main.yml
+++ b/roles/arteria-olink/tasks/main.yml
@@ -1,17 +1,15 @@
 ---
-- name: Deploy ngs2counts
-  copy:
-    src: "{{ olink_ngs2counts_dir }}/ngs2counts-{{ olink_ngs2counts_latest }}"
-    dest: "{{ arteria_node_ngs2counts_dest }}/ngs2counts-{{ olink_ngs2counts_latest }}"
-    mode: "0755"
-  tags: [olink_explore]
-
 - name: Create ngs2counts symlink
   file:
     src: "{{ olink_ngs2counts_dir }}/ngs2counts-{{ olink_ngs2counts_default }}"
-    dest: "{{ arteria_node_ngs2counts_dest }}/ngs2counts"
+    dest: "{{ arteria_service_src_path }}/ngs2counts"
     state: "link"
     force: true
-    mode: "0755"
-  tags: [olink_explore]
+    mode: "0775"
+ 
+- name: Clone ngs2counts nf workflow
+  git:
+    repo: "{{ olink_ngs2counts_nf_workflow }}"
+    dest: "{{ arteria_service_src_path }}"
+    version: "{{ olink_ngs2counts_nf_workflow_version }}"
 

--- a/roles/arteria-olink/tasks/main.yml
+++ b/roles/arteria-olink/tasks/main.yml
@@ -16,6 +16,6 @@
 - name: Clone ngs2counts nf workflow
   git:
     repo: "{{ olink_ngs2counts_nf_workflow }}"
-    dest: "{{ arteria_service_src_path }}"
+    dest: "{{ arteria_service_src_path }}/ngs2counts_nextflow"
     version: "{{ olink_ngs2counts_nf_workflow_version }}"
 

--- a/roles/arteria-olink/tasks/main.yml
+++ b/roles/arteria-olink/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Deploy ngs2counts
+  copy:
+    src: "{{ olink_ngs2counts_dir }}/ngs2counts-{{ olink_ngs2counts_latest }}"
+    dest: "{{ arteria_node_ngs2counts_dest }}/ngs2counts-{{ olink_ngs2counts_latest }}"
+    mode: "0755"
+  tags: [olink_explore]
+
+- name: Create ngs2counts symlink
+  file:
+    src: "{{ olink_ngs2counts_dir }}/ngs2counts-{{ olink_ngs2counts_default }}"
+    dest: "{{ arteria_node_ngs2counts_dest }}/ngs2counts"
+    state: "link"
+    force: true
+    mode: "0755"
+  tags: [olink_explore]
+

--- a/roles/arteria-sequencing-report-ws/templates/pipeline_configs/ngs2counts.yml.j2
+++ b/roles/arteria-sequencing-report-ws/templates/pipeline_configs/ngs2counts.yml.j2
@@ -1,0 +1,20 @@
+---
+
+main_workflow_path: "{{arteria_service_src_path}}/ngs2counts_nextflow/main.nf"
+# Note that in the following sections it is possible to do variable
+# substitution on the following variables:
+# - {runfolder_path}
+# - {ngs2counts_executable}
+# - {ngs2counts_extra_args}
+nextflow_parameters:
+  config: "{{arteria_service_src_path}}/ngs2counts_nextflow/nextflow.config"
+  profile: "uppmax"
+environment:
+  NXF_TEMP: "{{nextflow_env.NXF_TEMP}}"
+  NXF_WORK: "{runfolder_path}/.nextflow"
+  NXF_ANSI_LOG: "false"
+pipeline_parameters:
+  input_folder: "{runfolder_path}"
+  ngs2counts_executable: "{ngs2counts_executable}"
+  ngs2counts_extra_args: "{ngs2counts_extra_args}"
+  project: "{{uppmax_project}}"

--- a/roles/arteria-sequencing-report-ws/templates/pipeline_configs/ngs2counts.yml.j2
+++ b/roles/arteria-sequencing-report-ws/templates/pipeline_configs/ngs2counts.yml.j2
@@ -5,7 +5,6 @@ main_workflow_path: "{{arteria_service_src_path}}/ngs2counts_nextflow/main.nf"
 # substitution on the following variables:
 # - {runfolder_path}
 # - {ngs2counts_executable}
-# - {ngs2counts_extra_args}
 nextflow_parameters:
   config: "{{arteria_service_src_path}}/ngs2counts_nextflow/nextflow.config"
   profile: "uppmax"
@@ -16,5 +15,4 @@ environment:
 pipeline_parameters:
   input_folder: "{runfolder_path}"
   ngs2counts_executable: "{ngs2counts_executable}"
-  ngs2counts_extra_args: "{ngs2counts_extra_args}"
   project: "{{uppmax_project}}"


### PR DESCRIPTION
This PR adds an arteria-olink role which deploys `ngs2counts` binary and the `ngs2counts_nextflow` workflow (https://github.com/Molmed/ngs2counts_nextflow) to `<deployment>/sw/arteria/arteria-olink/` 

Development deployment tested and worked as expected.

 * New ngs2counts versions to be added should be uploaded to `/vulpes/ngi/containers/ngs2counts` on miarka3 and renamed `ngs2counts-<version>` 

Current versions uploaded:
```
/vulpes/ngi/containers/ngs2counts
├── ngs2counts-5.1.0
├── ngs2counts-6.1.2
└── ngs2counts-6.2.0
```

 * `ngs2counts_nextflow` version is set by commit hash .

This PR should not be merged until `ngs2counts_nextflow` is ready to be merged.

In collaboration with @matrulda 

EDIT 2026-07-13 by @matrulda:
This PR is ready to be merged now.

Things left to do:
- Update `olink_ngs2counts_nf_workflow_version` to the final verified version (verification not complete yet, but we are currently on rc2).
- The sequencing-report-service has been renamed to nextflow-runner

I will address these in a separate PR since the renaming will cause changes in a lot of files. 