### PR TITLE
Update seqinspector to 1.1.0

### DIFF
--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -75,7 +75,7 @@ pipelines:
     release: 2.3.0
     container_dir: "{{ biocontainers_dirname }}"
   - name: seqinspector
-    release: 1.0.1
+    release: 1.1.0
     container_dir: "{{ biocontainers_dirname }}"
 
 nf_core_delivery_readmes:


### PR DESCRIPTION
**Description**
Update seqinspector to 1.1.0

**Risk analysis**
Low risk. Not used in production yet.
