### PR TITLE
Remove log_path in config and bump arteria-delivery version

### DIFF
--- a/roles/arteria-delivery-ws/templates/delivery_app.config.j2
+++ b/roles/arteria-delivery-ws/templates/delivery_app.config.j2
@@ -11,5 +11,3 @@ alembic_path: "{{ alembic_path }}"
 path_to_mover: "{{ mover_path }}"
 project_links_directory: "{{ delivery_links }}"
 readme_directory: "{{ readme_directory }}"
-dds_conf:
-  log_path: "{{ arteria_service_log_dir }}/dds.log"


### PR DESCRIPTION
- This PR updates the arteria-delivery pre-release verion to [v3.4.1.](https://github.com/arteria-project/arteria-delivery/releases/tag/v3.4.1)
- It also removes delivery config `log_path` & `dds_conf` entries as they are no longer used.