### PR TITLE
Issue 407 multiple nextflow versions

### DIFF
--- a/env_vars/site_all_env_devel.yml.example
+++ b/env_vars/site_all_env_devel.yml.example
@@ -5,7 +5,8 @@ deployment_version: "{{ [branch_name, deploy_date, branch_hash] | join('.') }}"
 root_path: "{{ deployment_target }}/{{ deployment_version }}"
 proj_root: "{{ deployment_target }}/wildwest/"
 ngi_containers: "{{ proj_root }}/containers/"
-ngi_nextflow_plugins: "{{ proj_root }}/nextflow_plugins/"
+nextflow_root: "{{ proj_root }}/nextflow"
+nextflow_plugins_root: "{{ nextflow_root }}/nextflow_plugins/"
 
 # Ports
 tarzan_port: 4443

--- a/env_vars/site_all_env_production.yml
+++ b/env_vars/site_all_env_production.yml
@@ -5,8 +5,9 @@ deployment_version: "{{ branch_tag }}"
 root_path: "{{ deployment_target }}/{{ deployment_version }}"
 proj_root: "{{ static_proj_root }}"
 ngi_containers: "{{ deployment_remote_path }}/containers/"
-ngi_nextflow_plugins: "{{ deployment_remote_path }}/nextflow_plugins/"
 igenomes_dir: "{{ deployment_remote_path }}/igenomes"
+nextflow_root: "{{ deployment_remote_path }}/nextflow"
+nextflow_plugins_root: "{{ nextflow_root }}/nextflow_plugins/"
 
 # ngi_pipeline
 charon_base_url: https://charon.scilifelab.se

--- a/env_vars/site_all_env_staging.yml
+++ b/env_vars/site_all_env_staging.yml
@@ -6,7 +6,8 @@ deployment_version: "{{ deployment_version_t ~ '-' ~ branch_name if branch_name 
 root_path: "{{ deployment_target }}/{{ deployment_version }}"
 proj_root: "{{ deployment_target }}/wildwest/"
 ngi_containers: "{{ deployment_remote_path }}/containers/"
-ngi_nextflow_plugins: "{{ deployment_remote_path }}/nextflow_plugins/"
+nextflow_root: "{{ deployment_remote_path }}/nextflow"
+nextflow_plugins_root: "{{ nextflow_root }}/nextflow_plugins/"
 igenomes_dir: "{{ deployment_remote_path }}/igenomes"
 
 # statusdb

--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -2,7 +2,7 @@
 # Empty placeholder that gets filled by env_vars and/or tasks/set_paths.yml
 root_path:
 ngi_containers:
-ngi_nextflow_plugins:
+nextflow_root:
 igenomes_dir:
 
 sw_path: "{{ root_path }}/sw"

--- a/roles/nextflow/defaults/main.yml
+++ b/roles/nextflow/defaults/main.yml
@@ -1,24 +1,27 @@
 java_home: /sw/comp/java/OpenJDK_17+35/miarka/
 nextflow_java: "{{ java_home }}"
-nextflow_version_tag: 25.10.2
 nextflow_download_url: https://github.com/nextflow-io/nextflow/releases/download/v{{ nextflow_version_tag }}/nextflow
 nf_schema_version: 2.6.1
 nextflow_local_env:
-  NXF_HOME: "{{ nextflow_dest }}/workfiles"
+  NXF_HOME: "{{ nextflow_root }}/{{ nextflow_versions | first }}/workfiles"
   NXF_OPTS: -Xms1g -Xmx3500m
   NXF_JAVA_HOME: "{{ nextflow_java }}"
-  NXF_PLUGINS_DIR: "{{ ngi_nextflow_plugins }}"
+  NXF_PLUGINS_DIR: "{{ nextflow_plugins_root }}"
   PATH: "{{ tools_path.PATH }}"
 nextflow_env:
-  NXF_HOME: "{{ nextflow_dest }}/workfiles"
+  NXF_HOME: "{{ nextflow_root }}/{{ nextflow_versions | first }}/workfiles"
   NXF_LAUNCHER: "$PWD/work"
   NXF_TEMP: "{{ ngi_pipeline_nobackup }}/nextflow/temp"
   NXF_WORK: "{{ ngi_pipeline_nobackup }}/nextflow/work"
   NXF_OPTS: -Xms1g -Xmx3500m
   NXF_JAVA_HOME: "{{ nextflow_java }}"
-  NXF_PLUGINS_DIR: "{{ ngi_nextflow_plugins }}"
+  NXF_PLUGINS_DIR: "{{ nextflow_plugins_root }}"
   NXF_SINGULARITY_HOME_MOUNT: true
   PATH: "{{ tools_path.PATH }}"
+# First version in list is set as default
+nextflow_versions:
+  - "26.04.6"
+  - "25.10.2"
 nextflow_plugins:
   - name: nf-validation
     version: 1.1.2

--- a/roles/nextflow/tasks/install_version.yml
+++ b/roles/nextflow/tasks/install_version.yml
@@ -17,12 +17,12 @@
     mode: u=rwx
 
 - name: "Bootstrap Nextflow {{ nf_version }}"
-  shell: "./nextflow -version"
+  shell: "./nextflow run hello"
   environment:
     NXF_HOME: "{{ nf_version_dest }}/workfiles"
     NXF_OPTS: -Xms1g -Xmx3500m
     NXF_JAVA_HOME: "{{ nextflow_java }}"
-    NXF_PLUGINS_DIR: "{{ nextflow_plugins }}"
+    NXF_PLUGINS_DIR: "{{ nextflow_plugins_root }}"
     PATH: "{{ tools_path.PATH }}"
   args:
     chdir: "{{ nf_version_dest }}"

--- a/roles/nextflow/tasks/install_versions.yml
+++ b/roles/nextflow/tasks/install_versions.yml
@@ -1,0 +1,29 @@
+---
+
+- name: "Create directory for Nextflow {{ nf_version }}"
+  file:
+    path: "{{ nf_version_dest }}"
+    state: directory
+
+- name: "Create workfiles dir for Nextflow {{ nf_version }}"
+  file:
+    path: "{{ nf_version_dest }}/workfiles"
+    state: directory
+
+- name: "Download Nextflow {{ nf_version }}"
+  get_url:
+    url: "{{ nf_version_download_url }}"
+    dest: "{{ nf_version_dest }}/nextflow"
+    mode: u=rwx
+
+- name: "Bootstrap Nextflow {{ nf_version }}"
+  shell: "./nextflow -version"
+  environment:
+    NXF_HOME: "{{ nf_version_dest }}/workfiles"
+    NXF_OPTS: -Xms1g -Xmx3500m
+    NXF_JAVA_HOME: "{{ nextflow_java }}"
+    NXF_PLUGINS_DIR: "{{ nextflow_plugins }}"
+    PATH: "{{ tools_path.PATH }}"
+  args:
+    chdir: "{{ nf_version_dest }}"
+

--- a/roles/nextflow/tasks/main.yml
+++ b/roles/nextflow/tasks/main.yml
@@ -1,30 +1,26 @@
 ---
-# The steps within the comments can be effectively replaced by 'module load Nextflow'
-# Currently the module has problems being automatically initialized
-###
-
-- name: Create NextFlow directory
+- name: Create top-level NextFlow directory
   file:
-    path: "{{ nextflow_dest }}"
+    path: "{{ nextflow_root }}"
     state: directory
 
-- name: Create NextFlow installation subdirectory
-  file:
-    path: "{{ nextflow_dest }}/workfiles"
-    state: directory
+- name: Install each Nextflow version
+  include_tasks: install_version.yml
+  vars:
+    nf_version: "{{ item }}"
+    nf_version_plugins: "{{ nextflow_plugins_root }}"
+    nf_version_dest: "{{ nextflow_root }}/{{ item.version }}"
+    nf_version_download_url: "https://github.com/nextflow-io/nextflow/releases/download/v{{ item.version }}/nextflow"
+  loop: "{{ nextflow_versions }}"
+  loop_control:
+    loop_var: item
+  tags: nextflow_versions
 
-- name: Download NextFlow
-  get_url:
-    url: "{{ nextflow_download_url }}"
+- name: Deploy Nextflow version-selector wrapper
+  template:
+    src: "nextflow_wrapper.sh.j2"
     dest: "{{ nextflow_dest }}/nextflow"
-    mode: u=rwx
-
-# Resolved any problems. Run-time files are pushed to scratch
-- name: Install NextFlow
-  shell: "./nextflow"
-  environment: "{{ nextflow_local_env }}"
-  args:
-    chdir: "{{ nextflow_dest }}"
+    mode: u=rwx,g=rx,o=rx
 
 - name: Add NextFlow to $PATH
   lineinfile:
@@ -58,7 +54,7 @@
     # Path to java to be used for nextflow
     - export NXF_JAVA_HOME={{ nextflow_env.NXF_JAVA_HOME }}
     - export NXF_SINGULARITY_HOME_MOUNT={{ nextflow_env.NXF_SINGULARITY_HOME_MOUNT }}
-    - export NXF_PLUGINS_DIR={{ nextflow_env.NXF_PLUGINS_DIR }}
+    - export NXF_PLUGINS_DIR={{ nextflow_plugins_root }}
     - export NXF_HOME={{ nextflow_env.NXF_HOME }}
     - export NXF_OFFLINE='true'
 

--- a/roles/nextflow/tasks/main.yml
+++ b/roles/nextflow/tasks/main.yml
@@ -9,31 +9,36 @@
   vars:
     nf_version: "{{ item }}"
     nf_version_plugins: "{{ nextflow_plugins_root }}"
-    nf_version_dest: "{{ nextflow_root }}/{{ item.version }}"
-    nf_version_download_url: "https://github.com/nextflow-io/nextflow/releases/download/v{{ item.version }}/nextflow"
+    nf_version_dest: "{{ nextflow_root }}/{{ item }}"
+    nf_version_download_url: "https://github.com/nextflow-io/nextflow/releases/download/v{{ item }}/nextflow"
   loop: "{{ nextflow_versions }}"
   loop_control:
     loop_var: item
   tags: nextflow_versions
 
-- name: Deploy Nextflow version-selector wrapper
+- name: Deploy Nextflow version selector wrapper
   template:
     src: "nextflow_wrapper.sh.j2"
-    dest: "{{ nextflow_dest }}/nextflow"
+    dest: "{{ nextflow_root }}/nextflow"
     mode: u=rwx,g=rx,o=rx
 
 - name: Add NextFlow to $PATH
   lineinfile:
     dest: "{{ ngi_pipeline_conf }}/{{ bash_env_common_script }}"
-    line: "export PATH={{ nextflow_dest }}:$PATH"
+    line: "export PATH={{ nextflow_root }}:$PATH"
     backup: no
+
+- name: Create top-level NextFlow plugin directory
+  file:
+    path: "{{ nextflow_plugins_root }}"
+    state: directory
 
 - name: Download Nextflow plugins
   command: "./nextflow plugin install {{ item.name }}@{{ item.version }}"
   environment: "{{ nextflow_local_env }}"
   with_items: "{{ nextflow_plugins }}"
   args:
-    chdir: "{{ nextflow_dest }}"
+    chdir: "{{ nextflow_root }}"
   tags: plugins
 
 - name: Create miarka config
@@ -61,4 +66,4 @@
 - name: Store nextflow version in deployment
   lineinfile:
     dest: "{{ deployed_tool_versions }}"
-    line: "Nextflow: {{ nextflow_version_tag }}"
+    line: "Nextflow (default): {{ nextflow_versions | first }}"

--- a/roles/nextflow/templates/nextflow_wrapper.sh.j2
+++ b/roles/nextflow/templates/nextflow_wrapper.sh.j2
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Nextflow version selector for offline multi-version setup
+# Installed versions: {{ nextflow_versions | map(attribute='version') | join(', ') }}
+
+NXF_VER="${NXF_VER:-{{ nextflow_default_version }}}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION_DIR="${SCRIPT_DIR}/${NXF_VER}"
+
+if [ ! -x "${VERSION_DIR}/nextflow" ]; then
+    echo "ERROR: Nextflow version ${NXF_VER} is not installed." >&2
+    echo "Available versions: {{ nextflow_versions | map(attribute='version') | join(', ') }}" >&2
+    exit 1
+fi
+
+# Point NXF_HOME and NXF_PLUGINS_DIR to the version-specific directories
+export NXF_HOME="${VERSION_DIR}/workfiles"
+export NXF_OFFLINE='true'
+
+exec "${VERSION_DIR}/nextflow" "$@"
+

--- a/roles/nextflow/templates/nextflow_wrapper.sh.j2
+++ b/roles/nextflow/templates/nextflow_wrapper.sh.j2
@@ -1,15 +1,15 @@
 #!/bin/bash
 # Nextflow version selector for offline multi-version setup
-# Installed versions: {{ nextflow_versions | map(attribute='version') | join(', ') }}
+# Installed versions: {{ nextflow_versions | join(', ') }}
 
-NXF_VER="${NXF_VER:-{{ nextflow_default_version }}}"
+NXF_VER="${NXF_VER:-{{ nextflow_versions | first }}}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERSION_DIR="${SCRIPT_DIR}/${NXF_VER}"
 
 if [ ! -x "${VERSION_DIR}/nextflow" ]; then
     echo "ERROR: Nextflow version ${NXF_VER} is not installed." >&2
-    echo "Available versions: {{ nextflow_versions | map(attribute='version') | join(', ') }}" >&2
+    echo "Available versions: {{ nextflow_versions | join(', ') }}" >&2
     exit 1
 fi
 

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -18,6 +18,7 @@ biocontainers_dirname: biocontainers
 pipelines:
   - name: rnaseq
     release: "{{ rnaseq_tag }}"
+    nextflow_version: "25.10.2"
     container_dir: "{{ biocontainers_dirname }}"
     repository: NationalGenomicsInfrastructure/nfcore_rnaseq
   - name: sarek
@@ -38,6 +39,7 @@ pipelines:
     # https://github.com/NationalGenomicsInfrastructure/miarka-provision/pull/340
     # can be removed when upgrading the methylseq pipeline
     release: 4.2.0
+    nextflow_version: "25.10.2"
     container_dir: "{{ biocontainers_dirname }}"
     extra_parameters:
       references:
@@ -49,21 +51,26 @@ pipelines:
           sha1: 2b03cbf38a8e6816914b172f048a2fe896317df7
   - name: ampliseq
     release: 2.12.0
+    nextflow_version: "25.10.2"
     extra_parameters:
       silva_base_url: https://www.arb-silva.de/fileadmin/silva_databases/qiime
       silva_zip: Silva_132_release.zip
     container_dir: "{{ biocontainers_dirname }}"
   - name: atacseq
     release: 2.0
+    nextflow_version: "25.10.2"
     container_dir: "{{ biocontainers_dirname }}"
   - name: demultiplex
     release: "{{ demultiplex_tag }}"
+    nextflow_version: "25.10.2"
     container_dir: "{{ biocontainers_dirname }}"
   - name: pixelator
     release: 2.3.0
+    nextflow_version: "25.10.2"
     container_dir: "{{ biocontainers_dirname }}"
   - name: seqinspector
     release: 1.1.0
+    nextflow_version: "25.10.2"
     container_dir: "{{ biocontainers_dirname }}"
 
 nf_core_delivery_readmes:

--- a/roles/nf-core/tasks/pipeline.yml
+++ b/roles/nf-core/tasks/pipeline.yml
@@ -1,3 +1,4 @@
+---
 
 - name: create directories for {{ pipeline }} singularity images
   file:
@@ -59,6 +60,7 @@
     dest: "{{ ngi_pipeline_conf }}/{{ bash_env_script }}"
     line: >
           alias {{ pipeline }}='
+          NXF_VER={{ item.nextflow_version}}
           nextflow run {{ release_path }}/
           -profile uppmax
           -c {{ ngi_pipeline_conf }}/nextflow_miarka_{{ site }}.config

--- a/sync.yml
+++ b/sync.yml
@@ -23,7 +23,7 @@
           paths:
             - "{{ root_path }}"
             - "{{ ngi_containers }}"
-            - "{{ ngi_nextflow_plugins }}"
+            - "{{ nextflow_root }}"
             - "{{ igenomes_dir }}"
           recurse: yes
           excludes: "{{ exclude_pattern }}"
@@ -89,7 +89,7 @@
       with_items:
           - "{{ hostvars['deploy']['root_path'] | replace(deployment_remote_path, deployment_remote_path + '/.') }}"
           - "{{ hostvars['deploy']['ngi_containers'] | replace(deployment_remote_path, deployment_remote_path + '/.') }}"
-          - "{{ hostvars['deploy']['ngi_nextflow_plugins'] | replace(deployment_remote_path, deployment_remote_path + '/.') }}"
+          - "{{ hostvars['deploy']['nextflow_root'] | replace(deployment_remote_path, deployment_remote_path + '/.') }}"
           - "{{ hostvars['deploy']['igenomes_dir'] | replace(deployment_remote_path, deployment_remote_path + '/.') }}"
 
     - name: create or move the latest symlink to {{ deployment_version }}


### PR DESCRIPTION
WIP #407 

Introduced changes: Multiple nextflow versions are now installed and wrapper script makes sure that the right version is used based on the $NXF_VER env variable. 

```
nextflow/
├── 25.10.2
│   ├── nextflow
│   └── workfiles
├── 26.04.6
│   ├── nextflow
│   └── workfiles
├── nextflow <-- wrapper script
└── nextflow_plugins
```

TODO: 
- Installing the plugins fail. I think having them in a shared directory might be causing issues. It might be necessary to use the plugins dir in the workfiles dir of each nextflow installation. I have not yet properly looked into this though. 
- Set NXF_VER for workflows used by nextflow_runner_service. 

