### PR TITLE
Bump arteria-delivery pre-release versio for decentralizig DDS logs

### DIFF
--- a/host_vars/deploy/main.yml
+++ b/host_vars/deploy/main.yml
@@ -16,7 +16,7 @@ tools_path:
 
 # Python versions
 python2_version: 2.7
-python3_version: 3.11
+python3_version: 3.14
 
 #Nextflow defauts
 nextflow_dest: "{{ sw_path }}/nextflow"

--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v3.4.0-rc1
+arteria_delivery_version: v3.4.1
 
 arteria_delivery_wrapper: "{{ arteria_service_config_root }}/arteria-delivery_wrapper.sh"
 

--- a/roles/nf-core/defaults/main.yml
+++ b/roles/nf-core/defaults/main.yml
@@ -3,92 +3,92 @@ nf_core_env: "{{ sw_path }}/anaconda/envs/{{ nf_core_env_name }}"
 nf_core_version: 3.2.0
 nf_core_container_repo: docker://nfcore
 nf_core_vars:
-  NFCORE_NO_VERSION_CHECK: 1
-  APPTAINER_CACHEDIR: /scratch/{{ deployment_version }}/singularity_cache
-  APPTAINER_TMPDIR: /scratch/{{ deployment_version }}/singularity_temp
-  NXF_SINGULARITY_CACHEDIR: "{{ container_dir }}"
-  NXF_SINGULARITY_LIBRARYDIR: "{{ container_dir }}"
-  NXF_SINGULARITY_HOME_MOUNT: true
-  NXF_PLUGINS_DIR: "{{ nextflow_local_env.NXF_PLUGINS_DIR }}"
-  NXF_DISABLE_CHECK_LATEST: true
-  NXF_HOME: "{{ nextflow_local_env.NXF_HOME }}"
-  JAVA_HOME: "{{ nextflow_local_env.NXF_JAVA_HOME }}"
-  PATH: "{{ nf_core_env }}/bin:{{ tools_path.PATH }}"
+    NFCORE_NO_VERSION_CHECK: 1
+    APPTAINER_CACHEDIR: /scratch/{{ deployment_version }}/singularity_cache
+    APPTAINER_TMPDIR: /scratch/{{ deployment_version }}/singularity_temp
+    NXF_SINGULARITY_CACHEDIR: "{{ container_dir }}"
+    NXF_SINGULARITY_LIBRARYDIR: "{{ container_dir }}"
+    NXF_SINGULARITY_HOME_MOUNT: true
+    NXF_PLUGINS_DIR: "{{ nextflow_local_env.NXF_PLUGINS_DIR }}"
+    NXF_DISABLE_CHECK_LATEST: true
+    NXF_HOME: "{{ nextflow_local_env.NXF_HOME }}"
+    JAVA_HOME: "{{ nextflow_local_env.NXF_JAVA_HOME }}"
+    PATH: "{{ nf_core_env }}/bin:{{ tools_path.PATH }}"
 biocontainers_dirname: biocontainers
 pipelines:
-  - name: rnaseq
-    release: "{{ rnaseq_tag }}"
-    container_dir: "{{ biocontainers_dirname }}"
-    repository: NationalGenomicsInfrastructure/nfcore_rnaseq
-  - name: sarek
-    release: "{{ sarek_tag }}"
-    container_dir: "{{ biocontainers_dirname }}"
-    pipeline_specific_containers:
-      - vep-108.2
-      - snpeff-5.1
-    pipeline_genomes:
-      - GRCh38
-      - GRCh37
-      - GRCm38
-      - GRCm39
-      - CanFam3.1
-      - WBcel235
-  - name: methylseq
-    # TODO Evaluate if workaround implemented in
-    # https://github.com/NationalGenomicsInfrastructure/miarka-provision/pull/340
-    # can be removed when upgrading the methylseq pipeline
-    release: 4.2.0
-    container_dir: "{{ biocontainers_dirname }}"
-    extra_parameters:
-      references:
-        - name: pUC19
-          accession: L09137.2
-          sha1: 059f13457cb9469cbfb35755197170c99ae96a97
-        - name: lambda
-          accession: NC_001416.1
-          sha1: 2b03cbf38a8e6816914b172f048a2fe896317df7
-  - name: ampliseq
-    release: 2.12.0
-    extra_parameters:
-      silva_base_url: https://www.arb-silva.de/fileadmin/silva_databases/qiime
-      silva_zip: Silva_132_release.zip
-    container_dir: "{{ biocontainers_dirname }}"
-  - name: atacseq
-    release: 2.0
-    container_dir: "{{ biocontainers_dirname }}"
-  - name: viralrecon
-    release: 2.6.0
-    container_dir: "{{ biocontainers_dirname }}"
-  - name: rnafusion
-    release: 2.3.4
-    container_dir: "{{ biocontainers_dirname }}"
-  - name: nanoseq
-    release: 3.1.0
-    container_dir: "{{ biocontainers_dirname }}"
-  - name: scrnaseq
-    release: 2.3.0
-    container_dir: "{{ biocontainers_dirname }}"
-  - name: demultiplex
-    release: "{{ demultiplex_tag }}"
-    container_dir: "{{ biocontainers_dirname }}"
-  - name: pixelator
-    release: 2.3.0
-    container_dir: "{{ biocontainers_dirname }}"
-  - name: seqinspector
-    release: 1.1.0
-    container_dir: "{{ biocontainers_dirname }}"
+    - name: rnaseq
+      release: "{{ rnaseq_tag }}"
+      container_dir: "{{ biocontainers_dirname }}"
+      repository: NationalGenomicsInfrastructure/nfcore_rnaseq
+    - name: sarek
+      release: "{{ sarek_tag }}"
+      container_dir: "{{ biocontainers_dirname }}"
+      pipeline_specific_containers:
+          - vep-108.2
+          - snpeff-5.1
+      pipeline_genomes:
+          - GRCh38
+          - GRCh37
+          - GRCm38
+          - GRCm39
+          - CanFam3.1
+          - WBcel235
+    - name: methylseq
+      # TODO Evaluate if workaround implemented in
+      # https://github.com/NationalGenomicsInfrastructure/miarka-provision/pull/340
+      # can be removed when upgrading the methylseq pipeline
+      release: 4.2.0
+      container_dir: "{{ biocontainers_dirname }}"
+      extra_parameters:
+          references:
+              - name: pUC19
+                accession: L09137.2
+                sha1: 059f13457cb9469cbfb35755197170c99ae96a97
+              - name: lambda
+                accession: NC_001416.1
+                sha1: 2b03cbf38a8e6816914b172f048a2fe896317df7
+    - name: ampliseq
+      release: 2.12.0
+      extra_parameters:
+          silva_base_url: https://www.arb-silva.de/fileadmin/silva_databases/qiime
+          silva_zip: Silva_132_release.zip
+      container_dir: "{{ biocontainers_dirname }}"
+    - name: atacseq
+      release: 2.0
+      container_dir: "{{ biocontainers_dirname }}"
+    - name: viralrecon
+      release: 2.6.0
+      container_dir: "{{ biocontainers_dirname }}"
+    - name: rnafusion
+      release: 2.3.4
+      container_dir: "{{ biocontainers_dirname }}"
+    - name: nanoseq
+      release: 3.1.0
+      container_dir: "{{ biocontainers_dirname }}"
+    - name: scrnaseq
+      release: 2.3.0
+      container_dir: "{{ biocontainers_dirname }}"
+    - name: demultiplex
+      release: "{{ demultiplex_tag }}"
+      container_dir: "{{ biocontainers_dirname }}"
+    - name: pixelator
+      release: 2.3.0
+      container_dir: "{{ biocontainers_dirname }}"
+    - name: seqinspector
+      release: 1.1.1
+      container_dir: "{{ biocontainers_dirname }}"
 
 nf_core_delivery_readmes:
-  sarek:
-    - DELIVERY.README.SAREK.txt
-    - DELIVERY.README.SAREK.BATCH.txt
-    - DELIVERY.README.SAREK.WES.md
-    - DELIVERY.README.SAREK.md
-    - apply_recalibration.sh
-  rnaseq:
-    - DELIVERY.README.RNASEQ.md
-  methylseq:
-    - DELIVERY.README.METHYLSEQ.md
+    sarek:
+        - DELIVERY.README.SAREK.txt
+        - DELIVERY.README.SAREK.BATCH.txt
+        - DELIVERY.README.SAREK.WES.md
+        - DELIVERY.README.SAREK.md
+        - apply_recalibration.sh
+    rnaseq:
+        - DELIVERY.README.RNASEQ.md
+    methylseq:
+        - DELIVERY.README.METHYLSEQ.md
 
 awscli_env_name: awscli-env
 awscli_env: "{{ sw_path }}/anaconda/envs/{{ awscli_env_name }}"
@@ -97,9 +97,9 @@ aws_igenomes_repo: https://github.com/ewels/AWS-iGenomes.git
 aws_igenomes_commit: dda1d928fdb0d018aabbf91ac6ce8e153b699991
 aws_igenomes_dest: "{{ sw_path }}/AWS-iGenomes"
 igenomes:
-  - genome: Homo_sapiens
-    source: GATK
-    build: GRCh38
-    type: gatk
+    - genome: Homo_sapiens
+      source: GATK
+      build: GRCh38
+      type: gatk
 
 ncbi_eutils_url: https://eutils.ncbi.nlm.nih.gov/entrez/eutils

--- a/roles/ngi_pipeline/templates/miarka_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/miarka_ngi_config.yaml.j2
@@ -96,14 +96,14 @@ qc:
         - bioinfo-tools
     fastqc:
         load_modules:
-            - FastQC/0.11.5
+            - FastQC/0.11.9
         threads: 16
         options: ["--nogroup"]
     fastq_screen:
         config_path: "{{ ngi_pipeline_conf }}/fastq_screen.miarka.conf"
         load_modules:
             - bowtie2/2.3.4.1
-            - fastq_screen/0.11.1
+            - fastq_screen/0.15.2
         subsample_reads: 200000
         threads: 1
         make_md5: True

--- a/roles/scilifelab-metadata-templates/defaults/main.yml
+++ b/roles/scilifelab-metadata-templates/defaults/main.yml
@@ -1,3 +1,3 @@
 metadata_templates_repo: https://github.com/ScilifelabDataCentre/scilifelab-metadata-templates
 metadata_templates_dest: "{{ sw_path }}/scilifelab-metadata-templates"
-metadata_templates_version: 87a9174dbd0fb8725637d43cbfb76905bc6e02f6
+metadata_templates_version: 00db6841eb767aeef4f809020aa497713536e3eb

--- a/roles/scilifelab-metadata-templates/defaults/main.yml
+++ b/roles/scilifelab-metadata-templates/defaults/main.yml
@@ -1,3 +1,3 @@
 metadata_templates_repo: https://github.com/ScilifelabDataCentre/scilifelab-metadata-templates
 metadata_templates_dest: "{{ sw_path }}/scilifelab-metadata-templates"
-metadata_templates_version: eb95400f9d6f49762977ab58a737ff26d06d7391
+metadata_templates_version: 87a9174dbd0fb8725637d43cbfb76905bc6e02f6

--- a/roles/scilifelab-metadata-templates/defaults/main.yml
+++ b/roles/scilifelab-metadata-templates/defaults/main.yml
@@ -1,0 +1,3 @@
+metadata_templates_repo: https://github.com/ScilifelabDataCentre/scilifelab-metadata-templates
+metadata_templates_dest: "{{ sw_path }}/scilifelab-metadata-templates"
+metadata_templates_version: eb95400f9d6f49762977ab58a737ff26d06d7391

--- a/roles/scilifelab-metadata-templates/tasks/main.yml
+++ b/roles/scilifelab-metadata-templates/tasks/main.yml
@@ -1,0 +1,20 @@
+
+- name: Fetch scilifelab-metadata-templates from GitHub
+  git:
+    repo: "{{ metadata_templates_repo }}"
+    dest: "{{ metadata_templates_dest }}"
+    version: "{{ metadata_templates_version }}"
+    force: yes
+
+- name: Install scilifelab-metadata-templates
+  pip:
+    name: "file:{{ metadata_templates_dest }}[genomics]"
+    executable: "{{ ngi_pipeline_venv }}/bin/pip"
+
+
+- name: Store scilifelab-metadata-templates version and hash in deployment
+  lineinfile:
+    dest: "{{ deployed_tool_versions }}"
+    line: "{{ NGI_venv_name }}, {{ item.tool_name }}: {{ item.tool_version }}"
+  with_items:
+    - { tool_name: "scilifelab-metadata-templates", tool_version: "{{ metadata_templates_version }}" }

--- a/roles/taca/defaults/main.yml
+++ b/roles/taca/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 taca_ngi_repo: https://github.com/NationalGenomicsInfrastructure/taca-ngi-pipeline.git
 taca_ngi_dest: "{{ sw_path }}/taca-ngi-pipeline"
-taca_ngi_version: 52dc51bca7f08c5a3dd8c308a036436af25d7f27
+taca_ngi_version: 933602459ab7b348474d0d8c52136d0b103df410
 
 flowcell_parser_repo: https://github.com/NationalGenomicsInfrastructure/flowcell_parser.git
 flowcell_parser_dest: "{{ sw_path }}/flowcell_parser"
@@ -9,7 +9,7 @@ flowcell_parser_version: 286b54825a83ef5cfed5345752f56b7e93265a1a
 
 taca_repo: https://github.com/NationalGenomicsInfrastructure/TACA.git
 taca_dest: "{{ sw_path }}/TACA"
-taca_version: 764fe822cd5419d5c1a33b8cf222001084f2b59e
+taca_version: 1627c5c5afa7b71ede1d6e279066bded7213bd4e
 
 ngi_pipeline_analysisdir: "{{ ngi_pipeline_workdir }}/ANALYSIS"
 ngi_pipeline_datadir: "{{ ngi_pipeline_workdir }}/DATA"

--- a/roles/taca/meta/main.yml
+++ b/roles/taca/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - { role: setup_base_config, tags: setup_base_config }
   - { role: ngi_pipeline, tags: ngi_pipeline }
+  - { role: scilifelab-metadata-templates, tags: scilifelab-metadata-templates }


### PR DESCRIPTION
This MR bumps arteria-delivery version to the [pre-release version ](https://github.com/arteria-project/arteria-delivery/releases/tag/v3.4.1) that decentralizes DDS delivery logs