### PR TITLE
Bump arteria-delivery pre-release versio for decentralizig DDS logs

### DIFF
--- a/roles/arteria-delivery-ws/defaults/main.yml
+++ b/roles/arteria-delivery-ws/defaults/main.yml
@@ -7,7 +7,7 @@
 #
 # This will set corresponding paths and use the appropriate port.
 arteria_delivery_repo: https://github.com/arteria-project/arteria-delivery.git
-arteria_delivery_version: v3.4.0-rc1
+arteria_delivery_version: v3.4.1
 
 arteria_delivery_wrapper: "{{ arteria_service_config_root }}/arteria-delivery_wrapper.sh"
 


### PR DESCRIPTION
This MR bumps arteria-delivery version to the [pre-release version ](https://github.com/arteria-project/arteria-delivery/releases/tag/v3.4.1)that decentralizes DDS delivery logs