### PR TITLE
Fix pip install syntax for "Install scilifelab-metadata-templates" task

### DIFF
--- a/roles/scilifelab-metadata-templates/tasks/main.yml
+++ b/roles/scilifelab-metadata-templates/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Install scilifelab-metadata-templates
   pip:
-    name: "file:{{ metadata_templates_dest }}[genomics]"
+    name: "scilifelab-metadata-templates[genomics] @ file://{{ metadata_templates_dest }}"
     executable: "{{ ngi_pipeline_venv }}/bin/pip"
 
 


### PR DESCRIPTION
When doing the staging deployment I got the following error: 
```
TASK [scilifelab-metadata-templates : Install scilifelab-metadata-templates] **************************************************************************************************************************************
fatal: [deploy]: FAILED! => {"changed": false, "cmd": ["/vulpes/ngi/staging/260826.d4b2066/sw/anaconda/envs/NGI/bin/pip", "install", "file:/vulpes/ngi/staging/260826.d4b2066/sw/scilifelab-metadata-templates[genomics]"], "msg": "stdout: Processing /vulpes/ngi/staging/260826.d4b2066/sw/scilifelab-metadata-templates[genomics]\n\n:stderr: ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/vulpes/ngi/staging/260826.d4b2066/sw/scilifelab-metadata-templates[genomics]'\n\n"}
```

I think the syntax used in not supported by the pip module of our ansible version. The following change seems to solve it. 